### PR TITLE
Use value of email address not the form control

### DIFF
--- a/apps/maptio/src/app/modules/member-form/member-form.component.html
+++ b/apps/maptio/src/app/modules/member-form/member-form.component.html
@@ -187,7 +187,7 @@
     <p>
       <span *ngIf="duplicateUsers.length === 1; else multiplePeople">A person</span>
       with this 
-      <span *ngIf="memberForm.controls['email']; else duplicationOnName">email address </span>
+      <span *ngIf="memberForm.controls['email'].value; else duplicationOnName">email address </span>
       <span *ngIf="duplicateUsers.length === 1; else are">is</span>
       already
       <span *ngIf="duplicateUsers.length === 1; else members">a member</span>


### PR DESCRIPTION
### Issue
Follow-up to #681 

### Description
Incorrectly fixed one of the items in #681! Used form control instead of its value. Should not commit when so exhausted.