### PR TITLE
Correct null title for links

### DIFF
--- a/apps/maptio/src/app/app.module.ts
+++ b/apps/maptio/src/app/app.module.ts
@@ -37,7 +37,15 @@ export function markedOptionsFactory(): MarkedOptions {
     const renderer = new MarkedRenderer();
 
     renderer.link = (href: string, title: string, text: string) => {
-        return `<a href=${href} class="markdown-link" target="_blank" title=${title}>${text}</a>`;
+        let linkHtml = `<a href=${href} class="markdown-link" target="_blank"`
+
+        if (title) {
+          linkHtml += ` title=${title}`;
+        }
+
+        linkHtml += `>${text}</a>`;
+
+        return linkHtml
     }
 
     renderer.paragraph = (text: string) => {

--- a/apps/maptio/src/app/app.module.ts
+++ b/apps/maptio/src/app/app.module.ts
@@ -40,7 +40,7 @@ export function markedOptionsFactory(): MarkedOptions {
         let linkHtml = `<a href=${href} class="markdown-link" target="_blank"`
 
         if (title) {
-          linkHtml += ` title=${title}`;
+          linkHtml += ` title="${title}"`;
         }
 
         linkHtml += `>${text}</a>`;

--- a/apps/maptio/src/app/app.module.ts
+++ b/apps/maptio/src/app/app.module.ts
@@ -37,7 +37,7 @@ export function markedOptionsFactory(): MarkedOptions {
     const renderer = new MarkedRenderer();
 
     renderer.link = (href: string, title: string, text: string) => {
-        let linkHtml = `<a href=${href} class="markdown-link" target="_blank"`
+        let linkHtml = `<a href=${href} class="markdown-link" target="_blank"`;
 
         if (title) {
           linkHtml += ` title="${title}"`;
@@ -45,7 +45,7 @@ export function markedOptionsFactory(): MarkedOptions {
 
         linkHtml += `>${text}</a>`;
 
-        return linkHtml
+        return linkHtml;
     }
 
     renderer.paragraph = (text: string) => {


### PR DESCRIPTION
### Issue
Fixes #676 

### Description
Turns out we always added a null title to every link in markdown... unless they had a title explicitly set (and they almost never do, of course!). So, this bit of code only adds the title to the HTML if one is present in the markdown.