### PR TITLE
Show banner during free trial with handy CTAs

### DIFF
--- a/apps/maptio/src/app/core/core.module.ts
+++ b/apps/maptio/src/app/core/core.module.ts
@@ -11,6 +11,7 @@ import { ErrorPageComponent } from './error/error.page';
 import { UnauthorizedComponent } from './401/unauthorized.component';
 import { NotFoundComponent } from './404/not-found.component';
 import { HeaderComponent } from './header/header.component';
+import { OnboardingBannerComponent } from './header/onboarding-banner.component';
 import { FooterComponent } from './footer/footer.component';
 import { AccessGuard } from './guards/access.guard';
 import { ActivationGuard } from './guards/activation.guard';
@@ -38,13 +39,13 @@ export function tokenGetter(): string {
 @NgModule({
     declarations: [
         HeaderComponent,
+        OnboardingBannerComponent,
         FooterComponent,
         LoaderComponent,
         UnauthorizedComponent,
         NotFoundComponent,
         LoginErrorPageComponent,
         ErrorPageComponent,
-
     ],
     imports: [
         CommonModule,

--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -70,25 +70,17 @@
         class="navbar-text d-none d-md-flex align-items-center position-relative ml-auto mr-auto"
         *ngIf="team && isMap()"
       >
-        <span *ngIf="team?.name" class="text-muted mr-1"
-          >Organisation
+        <span
+          *ngIf="team?.name"
+          class="text-muted mr-1"
+        >
+          Organisation
           <a routerLink="/teams/{{ team?.team_id }}/{{ team?.getSlug() }}">
             {{ team?.name }}
           </a>
         </span>
-        <span
-          *ngIf="!team?.isPaying && !team.isExample"
-          style="bottom: -5px"
-          class="x-small text-green position-absolute"
-          >{{ team?.getRemainingTrialDays() }} days left on your free trial.
-          <a
-            routerLink="/teams/{{ team?.team_id }}/{{
-              team?.getSlug()
-            }}/billing"
-            >Subscribe now</a
-          >
-        </span>
       </li>
+
       <li
         class="nav-item dropdown d-none d-md-flex align-items-center"
         *ngIf="

--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -16,6 +16,7 @@
   *ngIf="
     (userService.isAuthenticated$ | async)
     && (isMap() || isHome() || isTeam())
+    && team?.isPaying === false
   "
 ></maptio-onboarding-banner>
 

--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -18,6 +18,7 @@
     && (isMap() || isHome() || isTeam())
     && team?.isPaying === false
   "
+  [team]="team"
 ></maptio-onboarding-banner>
 
 <nav

--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -12,41 +12,12 @@
   >
 </ng-template>
 
-<ng-template #freetrial>
-  This is a demo organisation... Ready to create your own?
-</ng-template>
-
-<ng-container
+<maptio-onboarding-banner
   *ngIf="
-    (userService.isAuthenticated$ | async) && (isMap() || isHome() || isTeam())
+    (userService.isAuthenticated$ | async)
+    && (isMap() || isHome() || isTeam())
   "
->
-  <nav
-    class="d-flex flex-column py-3 flex-md-row justify-content-center align-items-center align-items-md-baseline bg-gradient-inverse rounded-bottom text-white mx-3"
-    *ngIf="isSandbox"
-  >
-    <div class="h5 d-none d-md-block">
-      <ng-container *ngTemplateOutlet="freetrial"></ng-container>
-    </div>
-    <small class="text-center d-md-none">
-      <ng-container *ngTemplateOutlet="freetrial"></ng-container>
-    </small>
-
-    <button
-      class="d-none d-md-block btn btn-success mx-1"
-      (click)="openOnboarding()"
-    >
-      Start a 14 day free trial
-    </button>
-
-    <button
-      class="d-md-none btn-sm btn btn-success my-1"
-      (click)="openOnboarding()"
-    >
-      Start a 14 day free trial
-    </button>
-  </nav>
-</ng-container>
+></maptio-onboarding-banner>
 
 <nav
   class="d-flex header navbar navbar-expand-md navbar-light bg-transparent justify-content-between align-items-baseline pr-3"

--- a/apps/maptio/src/app/core/header/header.component.ts
+++ b/apps/maptio/src/app/core/header/header.component.ts
@@ -22,7 +22,6 @@ import { UserService } from '@maptio-shared/services/user/user.service';
 import { ErrorService } from '@maptio-shared/services/error/error.service';
 import { BillingService } from '@maptio-shared/services/billing/billing.service';
 import { LoaderService } from '@maptio-shared/components/loading/loader.service';
-import { OnboardingService } from '@maptio-shared/components/onboarding/onboarding.service';
 
 import { DatasetFactory } from '../http/map/dataset.factory';
 import { TeamFactory } from '../http/team/team.factory';
@@ -61,7 +60,6 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
     public loaderService: LoaderService,
     private cd: ChangeDetectorRef,
     private billingService: BillingService,
-    private onboarding: OnboardingService
   ) {
     const [teamDefined, teamUndefined] = partition(
       from(EmitterService.get('currentTeam')),
@@ -158,9 +156,5 @@ export class HeaderComponent implements OnInit, AfterViewInit, OnDestroy {
 
   isPricing() {
     return this.router.url.startsWith('/pricing');
-  }
-
-  openOnboarding() {
-    this.onboarding.open(this.user);
   }
 }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -18,6 +18,7 @@
     class="btn btn-info text-white"
     [href]="REQUEST_TRIAL_EXTENSION_EMAIL"
   >
+    <span class="onboarding-banner__emoji">⏳</span>
     Request longer
   </a>
 
@@ -25,6 +26,7 @@
     class="btn btn-success text-white"
     routerLink="{{ SUBSCRIBE_NOW_LINK }}"
   >
+    <span class="onboarding-banner__emoji">❤️</span>
     Subscribe now
   </a>
 
@@ -32,6 +34,7 @@
     class="btn btn-success text-white"
     [href]="BOOK_ONBOARDING_URL"
   >
+    <span class="onboarding-banner__emoji">💬</span>
     Book free Zoom help call
   </a>
 </nav>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -1,17 +1,7 @@
-<!-- <ng-template #freetrial>
-</ng-template> -->
-
 <nav
-  class="d-flex flex-column py-3 flex-md-row justify-content-center align-items-center align-items-md-baseline bg-gradient-inverse rounded-bottom text-white mx-3"
+  class="onboarding-banner"
   *ngIf="true"
 >
-  <!-- <div class="h5 d-none d-md-block">
-    <ng-container *ngTemplateOutlet="freetrial"></ng-container>
-  </div>
-  <small class="text-center d-md-none">
-    <ng-container *ngTemplateOutlet="freetrial"></ng-container>
-  </small> -->
-
   <div class="onboarding-banner__free-trial-text">
     Free trial time left: {{ team?.getRemainingTrialDays() }}
     day<span *ngIf="team?.getRemainingTrialDays() > 1">s</span>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -1,1 +1,30 @@
-<p>onboarding-banner works!</p>
+<ng-template #freetrial>
+  Free trial time left: {{ team?.getRemainingTrialDays() }}
+  day<span *ngIf="team?.getRemainingTrialDays() > 1">s</span>
+</ng-template>
+
+<nav
+  class="d-flex flex-column py-3 flex-md-row justify-content-center align-items-center align-items-md-baseline bg-gradient-inverse rounded-bottom text-white mx-3"
+  *ngIf="true"
+>
+  <div class="h5 d-none d-md-block">
+    <ng-container *ngTemplateOutlet="freetrial"></ng-container>
+  </div>
+  <small class="text-center d-md-none">
+    <ng-container *ngTemplateOutlet="freetrial"></ng-container>
+  </small>
+
+  <button
+    class="d-none d-md-block btn btn-success mx-1"
+    (click)="openOnboarding()"
+  >
+    Start a 14 day free trial
+  </button>
+
+  <button
+    class="d-md-none btn-sm btn btn-success my-1"
+    (click)="openOnboarding()"
+  >
+    Start a 14 day free trial
+  </button>
+</nav>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -32,6 +32,6 @@
     class="btn btn-success text-white"
     [href]="BOOK_ONBOARDING_URL"
   >
-    Book free onboarding
+    Book free Zoom help call
   </a>
 </nav>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -9,14 +9,14 @@
 
   <a
     class="btn btn-info text-white"
-    [href]="BOOK_ONBOARDING_URL"
+    [href]="REQUEST_TRIAL_EXTENSION_EMAIL"
   >
     Request longer
   </a>
 
   <a
     class="btn btn-success text-white"
-    [href]="BOOK_ONBOARDING_URL"
+    routerLink="{{ SUBSCRIBE_NOW_LINK }}"
   >
     Subscribe now
   </a>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -1,0 +1,1 @@
+<p>onboarding-banner works!</p>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -1,18 +1,21 @@
-<ng-template #freetrial>
-  Free trial time left: {{ team?.getRemainingTrialDays() }}
-  day<span *ngIf="team?.getRemainingTrialDays() > 1">s</span>
-</ng-template>
+<!-- <ng-template #freetrial>
+</ng-template> -->
 
 <nav
   class="d-flex flex-column py-3 flex-md-row justify-content-center align-items-center align-items-md-baseline bg-gradient-inverse rounded-bottom text-white mx-3"
   *ngIf="true"
 >
-  <div class="h5 d-none d-md-block">
+  <!-- <div class="h5 d-none d-md-block">
     <ng-container *ngTemplateOutlet="freetrial"></ng-container>
   </div>
   <small class="text-center d-md-none">
     <ng-container *ngTemplateOutlet="freetrial"></ng-container>
-  </small>
+  </small> -->
+
+  <div class="onboarding-banner__free-trial-text">
+    Free trial time left: {{ team?.getRemainingTrialDays() }}
+    day<span *ngIf="team?.getRemainingTrialDays() > 1">s</span>
+  </div>
 
   <button
     class="d-none d-md-block btn btn-success mx-1"

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -1,10 +1,17 @@
 <nav
   class="onboarding-banner"
-  *ngIf="true"
 >
   <div class="onboarding-banner__free-trial-text">
-    Free trial time left: {{ team?.getRemainingTrialDays() }}
-    day<span *ngIf="team?.getRemainingTrialDays() > 1">s</span>
+    <ng-container
+      *ngIf="remainingTrialDays >= 0; else noMoreTimeInFreeTrial"
+    >
+      Free trial time left: {{ remainingTrialDays }}
+      day<span *ngIf="remainingTrialDays > 1">s</span>
+    </ng-container>
+
+    <ng-template #noMoreTimeInFreeTrial>
+      Your free trial has ended
+    </ng-template>
   </div>
 
   <a

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -7,17 +7,10 @@
     day<span *ngIf="team?.getRemainingTrialDays() > 1">s</span>
   </div>
 
-  <button
-    class="d-none d-md-block btn btn-success mx-1"
-    (click)="openOnboarding()"
+  <a
+    class="btn btn-success text-white"
+    [href]="BOOK_ONBOARDING_URL"
   >
-    Start a 14 day free trial
-  </button>
-
-  <button
-    class="d-md-none btn-sm btn btn-success my-1"
-    (click)="openOnboarding()"
-  >
-    Start a 14 day free trial
-  </button>
+    Book free onboarding
+  </a>
 </nav>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -8,6 +8,20 @@
   </div>
 
   <a
+    class="btn btn-info text-white"
+    [href]="BOOK_ONBOARDING_URL"
+  >
+    Request longer
+  </a>
+
+  <a
+    class="btn btn-success text-white"
+    [href]="BOOK_ONBOARDING_URL"
+  >
+    Subscribe now
+  </a>
+
+  <a
     class="btn btn-success text-white"
     [href]="BOOK_ONBOARDING_URL"
   >

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.scss
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.scss
@@ -24,8 +24,9 @@
   }
 }
 
-// .onboarding-banner__free-trial-text {
-// }
+.onboarding-banner__emoji {
+  margin-right: 0.0625rem;
+}
 
 // .onboarding-banner__button {
 // }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.scss
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.scss
@@ -1,0 +1,19 @@
+.onboarding-banner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  margin: 0 -15px; // Break out of container
+
+  background-image: linear-gradient(to left, var(--maptio-accent), var(--maptio-blue));
+  color: #fff;
+
+  @media (min-width: 768px) {
+    align-items: baseline;
+    flex-direction: row;
+  }
+}
+
+// .onboarding-banner__free-trial-text {
+// }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.scss
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.scss
@@ -7,7 +7,7 @@
   margin: 0 -15px; // Break out of container
 
   background-image: linear-gradient(to left, var(--maptio-accent), var(--maptio-blue));
-  color: #fff;
+  color: white;
 
   @media (min-width: 768px) {
     align-items: baseline;
@@ -16,4 +16,7 @@
 }
 
 // .onboarding-banner__free-trial-text {
+// }
+
+// .onboarding-banner__button {
 // }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.scss
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.scss
@@ -27,6 +27,3 @@
 .onboarding-banner__emoji {
   margin-right: 0.0625rem;
 }
-
-// .onboarding-banner__button {
-// }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.scss
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 1rem;
+  padding: 0.75rem;
   margin: 0 -15px; // Break out of container
 
   background-image: linear-gradient(to left, var(--maptio-accent), var(--maptio-blue));
@@ -12,6 +12,15 @@
   @media (min-width: 768px) {
     align-items: baseline;
     flex-direction: row;
+  }
+}
+
+.onboarding-banner >  * + * {
+  margin-top: 0.5rem;
+
+  @media (min-width: 768px) {
+    margin-top: 0;
+    margin-left: 1rem;
   }
 }
 

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.spec.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OnboardingBannerComponent } from './onboarding-banner.component';
+
+describe('OnboardingBannerComponent', () => {
+  let component: OnboardingBannerComponent;
+  let fixture: ComponentFixture<OnboardingBannerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ OnboardingBannerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OnboardingBannerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'maptio-onboarding-banner',
+  templateUrl: './onboarding-banner.component.html',
+  styleUrls: ['./onboarding-banner.component.scss']
+})
+export class OnboardingBannerComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -1,15 +1,13 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
+
+import { Team } from '@maptio-shared/model/team.data';
+
 
 @Component({
   selector: 'maptio-onboarding-banner',
   templateUrl: './onboarding-banner.component.html',
   styleUrls: ['./onboarding-banner.component.scss']
 })
-export class OnboardingBannerComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+export class OnboardingBannerComponent {
+  @Input() team?: Team;
 }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -11,8 +11,7 @@ import { Team } from '@maptio-shared/model/team.data';
 })
 export class OnboardingBannerComponent {
   @Input() set team(team: Team) {
-    this.team = team;
-    this.remainingTrialDays = this.team.getRemainingTrialDays();
+    this.remainingTrialDays = team.getRemainingTrialDays();
   }
 
   remainingTrialDays: number;

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -10,7 +10,12 @@ import { Team } from '@maptio-shared/model/team.data';
   styleUrls: ['./onboarding-banner.component.scss']
 })
 export class OnboardingBannerComponent {
-  @Input() team?: Team;
+  @Input() set team(team: Team) {
+    this.team = team;
+    this.remainingTrialDays = this.team.getRemainingTrialDays();
+  }
+
+  remainingTrialDays: number;
 
   BOOK_ONBOARDING_URL = environment.BOOK_ONBOARDING_URL;
   REQUEST_TRIAL_EXTENSION_EMAIL = environment.REQUEST_TRIAL_EXTENSION_EMAIL;

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -13,4 +13,6 @@ export class OnboardingBannerComponent {
   @Input() team?: Team;
 
   BOOK_ONBOARDING_URL = environment.BOOK_ONBOARDING_URL;
+  REQUEST_TRIAL_EXTENSION_EMAIL = environment.REQUEST_TRIAL_EXTENSION_EMAIL;
+  SUBSCRIBE_NOW_LINK = environment.SUBSCRIBE_NOW_LINK;
 }

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 
+import { environment } from '@maptio-environment';
 import { Team } from '@maptio-shared/model/team.data';
 
 
@@ -10,4 +11,6 @@ import { Team } from '@maptio-shared/model/team.data';
 })
 export class OnboardingBannerComponent {
   @Input() team?: Team;
+
+  BOOK_ONBOARDING_URL = environment.BOOK_ONBOARDING_URL;
 }

--- a/apps/maptio/src/app/modules/home/components/dashboard/dashboard.component.html
+++ b/apps/maptio/src/app/modules/home/components/dashboard/dashboard.component.html
@@ -21,9 +21,9 @@
       <i class="fa fa-phone fa-stack-1x fa-inverse"></i>
     </span>
     <span>
-      <a target="blank" href="https://calendly.com/tomnixon/30min"
-        >Book a free mastery call</a
-      >
+      <a target="blank" href="https://calendly.com/tomnixon/30min">
+        Book a free Zoom help call
+      </a>
       with Maptio founder Tom Nixon
     </span>
   </div>

--- a/apps/maptio/src/app/shared/components/modal/modal.component.html
+++ b/apps/maptio/src/app/shared/components/modal/modal.component.html
@@ -22,8 +22,8 @@
         </div>
     </div>
     <div class="d-flex justify-content-end col-12 col-md mt-3 mt-md-0">
-        <button type="button" class="btn btn-outline-secondary mx-1" [class.invisible]="!previousActionName" (click)="previousStep()">{{previousActionName}}</button>
-        <button type="button" *ngIf="isSkippable" class="btn btn-link mx-1" (click)="nextStep()">I'll do this later</button>
-        <button type="button" *ngIf="!isSkippable" class="btn btn-success" [class.invisible]="!nextActionName" (click)="nextStep()">{{nextActionName}}</button>
+        <button type="button" class="btn btn-lg btn-outline-secondary mx-1" [class.invisible]="!previousActionName" (click)="previousStep()">{{previousActionName}}</button>
+        <button type="button" *ngIf="isSkippable" class="btn btn-lg btn-link mx-1" (click)="nextStep()">I'll do this later</button>
+        <button type="button" *ngIf="!isSkippable" class="btn btn-lg btn-success" [class.invisible]="!nextActionName" (click)="nextStep()">{{nextActionName}}</button>
     </div>
 </div>

--- a/apps/maptio/src/app/shared/components/onboarding/onboarding.component.html
+++ b/apps/maptio/src/app/shared/components/onboarding/onboarding.component.html
@@ -20,7 +20,7 @@
         <span class="text-accent">👋 {{user?.firstname}}</span>, your first map is just a few clicks away!
     </ng-template>
     <ng-template #guide>
-        We'll guide you through creating your first map, it should only take a few minutes.
+        Let's set up your organization. It will only take a minute.
     </ng-template>
 
 

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -2,7 +2,7 @@
 // environments
 
 export const commonEnvironment = {
-  BOOK_ONBOARDING_URL: 'https://calendly.com/tomnixon/maptio-onboarding',
+  BOOK_ONBOARDING_URL: 'https://calendly.com/tomnixon/30min',
   REQUEST_TRIAL_EXTENSION_EMAIL: 'mailto:support@maptio.com?subject=I need more time to try Maptio',
   SUBSCRIBE_NOW_LINK: '/pricing',
 };

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -3,4 +3,6 @@
 
 export const commonEnvironment = {
   BOOK_ONBOARDING_URL: 'https://calendly.com/tomnixon/maptio-onboarding',
+  REQUEST_TRIAL_EXTENSION_EMAIL: 'mailto:support@maptio.com?subject=I need more time to try Maptio',
+  SUBSCRIBE_NOW_LINK: '/pricing',
 };

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -1,0 +1,6 @@
+// This file is meant for all constants that will be shared between
+// environments
+
+export const commonEnvironment = {
+  BOOK_ONBOARDING_URL: 'https://calendly.com/tomnixon/maptio-onboarding',
+};

--- a/apps/maptio/src/environments/environment.prod.ts
+++ b/apps/maptio/src/environments/environment.prod.ts
@@ -1,4 +1,8 @@
+import { commonEnvironment } from "./environment.common";
+
 export const environment = {
+  ...commonEnvironment,
+
   production: true,
 
   auth: {

--- a/apps/maptio/src/environments/environment.staging.ts
+++ b/apps/maptio/src/environments/environment.staging.ts
@@ -2,7 +2,11 @@
 // `ng build --configuration=staging` replaces `environment.ts` with `environment.staging.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+import { commonEnvironment } from "./environment.common";
+
 export const environment = {
+  ...commonEnvironment,
+
   production: false,
 
   auth: {

--- a/apps/maptio/src/environments/environment.ts
+++ b/apps/maptio/src/environments/environment.ts
@@ -2,7 +2,11 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+import { commonEnvironment } from "./environment.common";
+
 export const environment = {
+  ...commonEnvironment,
+
   production: false,
 
   auth: {


### PR DESCRIPTION
### Issue
Closes #664

### Description
See description of #664.

Basically, introduced this banner after onboarding and so consolidates a few other places we've been doing something similar:
![Screenshot 2022-05-10 at 14 32 14](https://user-images.githubusercontent.com/4092165/167640556-cbc14dc4-cceb-4b37-84bb-bf0e6b68481d.png)

Also tackles a few other smaller bits and bobs, copy changes and so on.