### PR TITLE
Counteract weird emoji width in production

### DIFF
--- a/apps/maptio/src/app/core/header/onboarding-banner.component.scss
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.scss
@@ -25,5 +25,9 @@
 }
 
 .onboarding-banner__emoji {
+  // Counteract the emoji having a different width in production
+  width: 1.25rem;
+  display: inline-block;
+
   margin-right: 0.0625rem;
 }


### PR DESCRIPTION
### Issue
Quick follow-up to #699 

### Description
Turns out... emojis end up having a different width in production. 📏🤷🏻 
This sets the width explicitly to ensure the look I've been aiming for.
