### PR TITLE
Add toggle between annual and monthly pricing

### DIFF
--- a/apps/maptio/src/app/config/environment.ts
+++ b/apps/maptio/src/app/config/environment.ts
@@ -31,10 +31,6 @@ export const environment = {
     DEFAULT_AUTHORITY_TERMINOLOGY: "Lead",
     DEFAULT_HELPER_TERMINOLOGY: "Contributor",
 
-    BILLING_STARTER_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan12",
-    BILLING_SMALL_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan50",
-    BILLING_STANDARD_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan",
-
     BILLING_TEST_PLAN: "https://maptio-test.chargebee.com/hosted_pages/plans/standard-plan",
 
     BILLING_PORTAL: "https://maptio.chargebeeportal.com/portal/login",

--- a/apps/maptio/src/app/modules/payment/pages/pricing/billing-schedule.enum.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/billing-schedule.enum.ts
@@ -1,4 +1,4 @@
 export enum BillingSchedule {
-  Monthly,
-  Annual,
+  MONTHLY = 'MONTHLY',
+  ANNUAL = 'ANNUAL',
 }

--- a/apps/maptio/src/app/modules/payment/pages/pricing/billing-schedule.enum.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/billing-schedule.enum.ts
@@ -1,0 +1,4 @@
+export enum BillingSchedule {
+  Monthly,
+  Annual,
+}

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
@@ -9,7 +9,7 @@
 
     <div *ngIf="price; else contactUsPrice" class="card-text">
       <span class="display-4">${{ price }} </span>
-      <sup class="text-top">per month</sup>
+      <sup class="text-top">per {{ billingPeriod }}</sup>
     </div>
 
     <ng-template #contactUsPrice>

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
@@ -9,7 +9,7 @@
 
     <div *ngIf="price; else contactUsPrice" class="card-text">
       <span class="display-4">${{ price }} </span>
-      <sup class="text-top">per {{ billingPeriod }}</sup>
+      <sup class="text-top">per month</sup>
     </div>
 
     <ng-template #contactUsPrice>

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
@@ -20,6 +20,7 @@ export class PaymentPlanComponent implements OnChanges {
 
   price: number;
   billingLink: string;
+  billingPeriod: string;
 
   constructor(public userService: UserService) { }
 
@@ -27,6 +28,8 @@ export class PaymentPlanComponent implements OnChanges {
     if (this.prices && this.billingLinks && this.billingSchedule) {
       this.price = this.prices[this.billingSchedule];
       this.billingLink = this.billingLinks[this.billingSchedule];
+      this.billingPeriod = this.billingSchedule ===
+        BillingSchedule.MONTHLY ? 'month' : 'year';
     }
   }
 }

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
@@ -1,19 +1,32 @@
-import { Component, HostBinding, Input } from '@angular/core';
+import { Component, HostBinding, Input, OnChanges } from '@angular/core';
 
 import { UserService } from '@maptio-shared/services/user/user.service';
+
+import { BillingSchedule } from './billing-schedule.enum';
 
 
 @Component({
   selector: 'maptio-payment-plan',
   templateUrl: './payment-plan.component.html',
 })
-export class PaymentPlanComponent {
+export class PaymentPlanComponent implements OnChanges {
   @HostBinding('class') classes = 'col-12 col-md-3 accent-blue rounded-bottom box-shadow mx-2 my-3';
 
   @Input() name: string;
-  @Input() price: number;
   @Input() text: number;
-  @Input() billingLink: string;
+  @Input() billingSchedule: BillingSchedule;
+  @Input() prices: { [key in BillingSchedule]: number };
+  @Input() billingLinks: { [key in BillingSchedule]: string };
+
+  price: number;
+  billingLink: string;
 
   constructor(public userService: UserService) { }
+
+  ngOnChanges() {
+    if (this.prices && this.billingLinks && this.billingSchedule) {
+      this.price = this.prices[this.billingSchedule];
+      this.billingLink = this.billingLinks[this.billingSchedule];
+    }
+  }
 }

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
@@ -20,7 +20,6 @@ export class PaymentPlanComponent implements OnChanges {
 
   price: number;
   billingLink: string;
-  billingPeriod: string;
 
   constructor(public userService: UserService) { }
 
@@ -28,8 +27,6 @@ export class PaymentPlanComponent implements OnChanges {
     if (this.prices && this.billingLinks && this.billingSchedule) {
       this.price = this.prices[this.billingSchedule];
       this.billingLink = this.billingLinks[this.billingSchedule];
-      this.billingPeriod = this.billingSchedule ===
-        BillingSchedule.MONTHLY ? 'month' : 'year';
     }
   }
 }

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -43,6 +43,7 @@
       <maptio-payment-plan
         [name]="'Starter'"
         [text]="'1 - 12 people'"
+        [billingSchedule]="billingScheduleChoice"
         [prices]="{
           MONTHLY: BILLING_PLANS.STARTER_MONTHLY_COST,
           ANNUAL: BILLING_PLANS.STARTER_ANNUAL_COST
@@ -51,25 +52,38 @@
           MONTHLY: BILLING_PLANS.STARTER_MONTHLY_URL,
           ANNUAL: BILLING_PLANS.STARTER_ANNUAL_URL
         }"
-        [billingSchedule]="billingScheduleChoice"
       >
       </maptio-payment-plan>
 
-      <!-- <maptio-payment-plan
+      <maptio-payment-plan
         [name]="'Small'"
-        [price]="50"
         [text]="'13 - 35 people'"
-        [billingLink]="BILLING_SMALL_PLAN"
+        [billingSchedule]="billingScheduleChoice"
+        [prices]="{
+          MONTHLY: BILLING_PLANS.SMALL_MONTHLY_COST,
+          ANNUAL: BILLING_PLANS.SMALL_ANNUAL_COST
+        }"
+        [billingLinks]="{
+          MONTHLY: BILLING_PLANS.SMALL_MONTHLY_URL,
+          ANNUAL: BILLING_PLANS.SMALL_ANNUAL_URL
+        }"
       >
       </maptio-payment-plan>
 
       <maptio-payment-plan
         [name]="'Standard plan'"
-        [price]="99"
         [text]="'36 - 200 people'"
-        [billingLink]="BILLING_STANDARD_PLAN"
+        [billingSchedule]="billingScheduleChoice"
+        [prices]="{
+          MONTHLY: BILLING_PLANS.STANDARD_MONTHLY_COST,
+          ANNUAL: BILLING_PLANS.STANDARD_ANNUAL_COST
+        }"
+        [billingLinks]="{
+          MONTHLY: BILLING_PLANS.STANDARD_MONTHLY_URL,
+          ANNUAL: BILLING_PLANS.STANDARD_ANNUAL_URL
+        }"
       >
-      </maptio-payment-plan> -->
+      </maptio-payment-plan>
 
       <maptio-payment-plan
         [name]="'Larger organizations'"

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -19,6 +19,26 @@
       No minimum contract length.
     </p>
 
+    <div
+      ngbRadioGroup
+      [(ngModel)]="billingScheduleChoice"
+      class="btn-group btn-group-toggle"
+      name="radioBasic"
+    >
+      <label ngbButtonLabel class="btn-primary">
+        <input ngbButton type="radio" [value]="BillingSchedule.Annual">
+        Annual billing
+      </label>
+
+      <label ngbButtonLabel class="btn-primary">
+        <input ngbButton type="radio" [value]="BillingSchedule.Monthly">
+        Monthly billing
+      </label>
+    </div>
+
+    <hr>
+    <pre>{{ billingScheduleChoice }}</pre>
+
     <div class="d-flex flex-column flex-md-row justify-content-center align-items-stretch">
       <maptio-payment-plan
         [name]="'Starter'"

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -27,6 +27,7 @@
     >
       <label
         ngbButtonLabel
+        class="btn-lg"
         [class]="
           billingScheduleChoice === BillingSchedule.ANNUAL ?
           'btn-success' : 'btn-light'
@@ -38,6 +39,7 @@
 
       <label
         ngbButtonLabel
+        class="btn-lg"
         [class]="
           billingScheduleChoice === BillingSchedule.MONTHLY ?
           'btn-success' : 'btn-light'

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -26,12 +26,12 @@
       name="radioBasic"
     >
       <label ngbButtonLabel class="btn-primary">
-        <input ngbButton type="radio" [value]="BillingSchedule.Annual">
+        <input ngbButton type="radio" [value]="BillingSchedule.ANNUAL">
         Annual billing
       </label>
 
       <label ngbButtonLabel class="btn-primary">
-        <input ngbButton type="radio" [value]="BillingSchedule.Monthly">
+        <input ngbButton type="radio" [value]="BillingSchedule.MONTHLY">
         Monthly billing
       </label>
     </div>
@@ -42,13 +42,20 @@
     <div class="d-flex flex-column flex-md-row justify-content-center align-items-stretch">
       <maptio-payment-plan
         [name]="'Starter'"
-        [price]="20"
         [text]="'1 - 12 people'"
-        [billingLink]="BILLING_STARTER_PLAN"
+        [prices]="{
+          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_COST,
+          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_COST
+        }"
+        [billingLinks]="{
+          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_URL,
+          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_URL
+        }"
+        [billingSchedule]="billingScheduleChoice"
       >
       </maptio-payment-plan>
 
-      <maptio-payment-plan
+      <!-- <maptio-payment-plan
         [name]="'Small'"
         [price]="50"
         [text]="'13 - 35 people'"
@@ -62,12 +69,11 @@
         [text]="'36 - 200 people'"
         [billingLink]="BILLING_STANDARD_PLAN"
       >
-      </maptio-payment-plan>
+      </maptio-payment-plan> -->
 
       <maptio-payment-plan
         [name]="'Larger organizations'"
         [text]="'200+ people'"
-        [billingLink]="BILLING_SMALL_PLAN"
       >
       </maptio-payment-plan>
     </div>

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -22,22 +22,31 @@
     <div
       ngbRadioGroup
       [(ngModel)]="billingScheduleChoice"
-      class="btn-group btn-group-toggle"
+      class="btn-group btn-group-toggle mb-3"
       name="radioBasic"
     >
-      <label ngbButtonLabel class="btn-primary">
+      <label
+        ngbButtonLabel
+        [class]="
+          billingScheduleChoice === BillingSchedule.ANNUAL ?
+          'btn-success' : 'btn-light'
+        "
+      >
         <input ngbButton type="radio" [value]="BillingSchedule.ANNUAL">
         Annual billing
       </label>
 
-      <label ngbButtonLabel class="btn-primary">
+      <label
+        ngbButtonLabel
+        [class]="
+          billingScheduleChoice === BillingSchedule.MONTHLY ?
+          'btn-success' : 'btn-light'
+        "
+      >
         <input ngbButton type="radio" [value]="BillingSchedule.MONTHLY">
         Monthly billing
       </label>
     </div>
-
-    <hr>
-    <pre>{{ billingScheduleChoice }}</pre>
 
     <div class="d-flex flex-column flex-md-row justify-content-center align-items-stretch">
       <maptio-payment-plan

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 
-import { environment } from '@maptio-config/environment';
+import { environment } from '@maptio-environment';
 import { UserService } from '@maptio-shared/services/user/user.service';
 
 import { BillingSchedule } from './billing-schedule.enum';
@@ -11,13 +11,10 @@ import { BillingSchedule } from './billing-schedule.enum';
   templateUrl: './pricing.page.html'
 })
 export class PricingComponent {
-  public BILLING_STARTER_PLAN = environment.BILLING_STARTER_PLAN;
-  public BILLING_SMALL_PLAN = environment.BILLING_SMALL_PLAN;
-  public BILLING_STANDARD_PLAN = environment.BILLING_STANDARD_PLAN;
-  public BILLING_PORTAL = environment.BILLING_PORTAL;
-
+  BILLING_PLANS = environment.BILLING_PLANS;
   BillingSchedule = BillingSchedule;
-  billingScheduleChoice = BillingSchedule.Monthly;
+
+  billingScheduleChoice = BillingSchedule.MONTHLY;
 
   constructor(public userService: UserService) { }
 }

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.ts
@@ -3,6 +3,8 @@ import { Component } from '@angular/core';
 import { environment } from '@maptio-config/environment';
 import { UserService } from '@maptio-shared/services/user/user.service';
 
+import { BillingSchedule } from './billing-schedule.enum';
+
 
 @Component({
   selector: 'maptio-pricing',
@@ -13,6 +15,9 @@ export class PricingComponent {
   public BILLING_SMALL_PLAN = environment.BILLING_SMALL_PLAN;
   public BILLING_STANDARD_PLAN = environment.BILLING_STANDARD_PLAN;
   public BILLING_PORTAL = environment.BILLING_PORTAL;
+
+  BillingSchedule = BillingSchedule;
+  billingScheduleChoice = BillingSchedule.Monthly;
 
   constructor(public userService: UserService) { }
 }

--- a/apps/maptio/src/app/modules/payment/payment.module.ts
+++ b/apps/maptio/src/app/modules/payment/payment.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { SanitizerModule } from '@maptio-shared/sanitizer.module';
 import { LoginModule } from '@maptio-login/login.module';
@@ -18,6 +21,8 @@ import { PaymentRoutingModule } from './payment.routing';
   ],
   imports: [
     CommonModule,
+    FormsModule,
+    NgbModule,
     SanitizerModule,
     PaymentRoutingModule,
     LoginModule,

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -5,4 +5,14 @@ export const commonEnvironment = {
   BOOK_ONBOARDING_URL: 'https://calendly.com/tomnixon/30min',
   REQUEST_TRIAL_EXTENSION_EMAIL: 'mailto:support@maptio.com?subject=I need more time to try Maptio',
   SUBSCRIBE_NOW_LINK: '/pricing',
+
+  BILLING_PLANS: {
+    STARTER_MONTHLY_COST: '20',
+    STARTER_MONTHLY_URL: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan12",
+    STARTER_ANNUAL_COST: '18',
+    STARTER_ANNUAL_URL: "https://maptio.chargebee.com/hosted_pages/plans/annual_12_18",
+
+    SMALL_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan50",
+    STANDARD_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan",
+  }
 };

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -8,11 +8,18 @@ export const commonEnvironment = {
 
   BILLING_PLANS: {
     STARTER_MONTHLY_COST: '20',
-    STARTER_MONTHLY_URL: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan12",
+    STARTER_MONTHLY_URL: 'https://maptio.chargebee.com/hosted_pages/plans/standard-plan12',
     STARTER_ANNUAL_COST: '18',
-    STARTER_ANNUAL_URL: "https://maptio.chargebee.com/hosted_pages/plans/annual_12_18",
+    STARTER_ANNUAL_URL: 'https://maptio.chargebee.com/hosted_pages/plans/annual_12_18',
 
-    SMALL_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan50",
-    STANDARD_PLAN: "https://maptio.chargebee.com/hosted_pages/plans/standard-plan",
+    SMALL_MONTHLY_COST: '50',
+    SMALL_MONTHLY_URL: 'https://maptio.chargebee.com/hosted_pages/plans/standard-plan50',
+    SMALL_ANNUAL_COST: '45',
+    SMALL_ANNUAL_URL: 'https://maptio.chargebee.com/hosted_pages/plans/annual_35_50',
+
+    STANDARD_MONTHLY_COST: '99',
+    STANDARD_MONTHLY_URL: 'https://maptio.chargebee.com/hosted_pages/plans/standard-plan',
+    STANDARD_ANNUAL_COST: '89',
+    STANDARD_ANNUAL_URL: 'https://maptio.chargebee.com/hosted_pages/plans/annual-standard-plan',
   }
 };


### PR DESCRIPTION
### Issue
Fixes #705 

### Description
See the issue for the purpose.

Uses [bootstrap's radio button groups](https://getbootstrap.com/docs/4.0/components/buttons/#checkbox-and-radio-buttons) along with their [ng-bootstrap implementation](https://ng-bootstrap.github.io/releases/9.x/#/components/buttons/examples#radio).

A screenshot of the result:
![Screenshot 2022-05-12 at 15 47 26](https://user-images.githubusercontent.com/4092165/168103064-c595f624-c78b-4f3b-9460-9d05d4a366da.png)

