### PR TITLE
Add info tooltips linking to knowledge base in two key areas

### DIFF
--- a/apps/maptio/src/app/config/environment.ts
+++ b/apps/maptio/src/app/config/environment.ts
@@ -19,6 +19,7 @@ export const environment = {
     CLOUDINARY_PROFILE_TAGNAME: "profile",
 
     KB_URL_PERMISSIONS: "https://github.com/Maptio/maptio/wiki/User-permission-types",
+    KB_URL_ROLE_TYPES: "https://github.com/Maptio/maptio/wiki/Working-with-roles",
     KB_URL_HOME: "https://github.com/Maptio/maptio/wiki/Maptio-Help-and-Support",
     KB_URL_INTEGRATIONS: "https://maptio.outseta.com/support/kb#/articles/2amRZEmJ/integrations",
 

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -19,7 +19,7 @@
     [href]="REQUEST_TRIAL_EXTENSION_EMAIL"
   >
     <span class="onboarding-banner__emoji">⏳</span>
-    Request longer
+    Request more time
   </a>
 
   <a

--- a/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
+++ b/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
@@ -42,12 +42,15 @@
 
         <div class="col-4">Email</div>
 
-        <div class="col-2 nowrap">
+        <a
+          class="col-2 nowrap text-decoration-none"
+          ngbTooltip="Click to go to our help hub and watch video about user permission types"
+          href="{{ KB_URL_PERMISSIONS }}"
+          target="blank"
+        >
           Permission type
-          <a href="{{ KB_URL_PERMISSIONS }}" target="blank">
-            <i class="fa fa-info-circle text-muted" aria-hidden="true"></i>
-          </a>
-        </div>
+          <i class="fa fa-info-circle text-muted" aria-hidden="true"></i>
+        </a>
       </div>
     </div>
 

--- a/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
+++ b/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
@@ -44,7 +44,7 @@
 
         <a
           class="col-2 nowrap mb-0 text-uppercase text-bold text-gray-light small text-decoration-none"
-          ngbTooltip="Click to go to our help hub and watch video about user permission types"
+          ngbTooltip="Learn about permission types"
           href="{{ KB_URL_PERMISSIONS }}"
           target="blank"
           container="body"

--- a/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
+++ b/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
@@ -44,7 +44,7 @@
 
         <a
           class="col-2 nowrap mb-0 text-uppercase text-bold text-gray-light small text-decoration-none"
-          ngbTooltip="Click to go to our help hub and watch video about the difference between custom and library roles"
+          ngbTooltip="Click to go to our help hub and watch video about user permission types"
           href="{{ KB_URL_PERMISSIONS }}"
           target="blank"
           container="body"

--- a/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
+++ b/apps/maptio/src/app/modules/team/pages/team-members/members.component.html
@@ -22,7 +22,7 @@
   </div>
 
   <div class="my-4">
-    <div class="d-none d-md-block border-bottom py-2 text-muted">
+    <div class="d-none d-md-block border-bottom pt-4 text-muted">
       <div class="d-flex align-items-center">
         <div
           *permissionsOnly="Permissions.canEditUser"
@@ -38,18 +38,19 @@
           ></button>
         </div>
 
-        <div class="col-3">Name</div>
+        <div class="col-3 text-uppercase text-bold text-gray-light small">Name</div>
 
-        <div class="col-4">Email</div>
+        <div class="col-4 text-uppercase text-bold text-gray-light small">Email</div>
 
         <a
-          class="col-2 nowrap text-decoration-none"
-          ngbTooltip="Click to go to our help hub and watch video about user permission types"
+          class="col-2 nowrap mb-0 text-uppercase text-bold text-gray-light small text-decoration-none"
+          ngbTooltip="Click to go to our help hub and watch video about the difference between custom and library roles"
           href="{{ KB_URL_PERMISSIONS }}"
           target="blank"
+          container="body"
         >
           Permission type
-          <i class="fa fa-info-circle text-muted" aria-hidden="true"></i>
+          <i class="fa fa-info-circle text-gray-light" aria-hidden="true"></i>
         </a>
       </div>
     </div>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/helper-role-input.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/helper-role-input.component.html
@@ -41,7 +41,7 @@
   <div *ngIf="!isDirectoryView" class="my-2">
     <a
       class="mb-0 text-uppercase text-bold text-gray-light small text-decoration-none"
-      ngbTooltip="Click to go to our help hub and watch video about the difference between custom and library roles"
+      ngbTooltip="Learn about custom and library roles"
       href="{{ KB_URL_ROLE_TYPES }}"
       target="blank"
       container="body"

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/helper-role-input.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/helper-role-input.component.html
@@ -39,6 +39,17 @@
   </small>
 
   <div *ngIf="!isDirectoryView" class="my-2">
+    <a
+      class="mb-0 text-uppercase text-bold text-gray-light small text-decoration-none"
+      ngbTooltip="Click to go to our help hub and watch video about the difference between custom and library roles"
+      href="{{ KB_URL_ROLE_TYPES }}"
+      target="blank"
+      container="body"
+    >
+      Role type
+      <i class="fa fa-info-circle text-gray-light" aria-hidden="true"></i>
+    </a>
+
     <div class="custom-control custom-radio">
       <input
         type="radio"

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/helper-role-input.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/helper-role-input.component.ts
@@ -3,6 +3,8 @@ import { FormGroup, FormControl, Validators, ValidatorFn, ValidationErrors } fro
 
 import { Subscription } from "rxjs";
 
+import { environment } from '@maptio-config/environment';
+
 import { Role } from "../../../../../../../shared/model/role.data";
 import { Helper } from "../../../../../../../shared/model/helper.data";
 import { RoleLibraryService } from "../../../../../services/role-library.service";
@@ -37,6 +39,8 @@ export class InitiativeHelperRoleInputComponent implements OnInit, OnDestroy {
 
     @Output("cancel") cancel = new EventEmitter<void>();
     @Output("save") save = new EventEmitter<void>();
+
+    KB_URL_ROLE_TYPES = environment.KB_URL_ROLE_TYPES;
 
     roleForm: FormGroup;
     title = new FormControl();

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/vacancies-input.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/details/parts/helpers/vacancies-input.component.html
@@ -15,7 +15,7 @@
 
       <button *ngIf="isPickRoleMode" class="btn btn-link btn-sm" (click)="isPickRoleMode=false">Cancel</button>
       <button [class.invisible]="isPickRoleMode || isCreateRoleMode || isEditRoleMode || isUnauthorized" class="btn btn-link btn-sm"
-          (click)="!isUnauthorized && isPickRoleMode=true">Add role</button>
+          (click)="!isUnauthorized && isPickRoleMode=true">Add role vacancy</button>
   </div>
 
   <initiative-helper-role-select *ngIf="isPickRoleMode" [roles]="initiative?.vacancies" (pick)="onPickRole($event)"
@@ -43,7 +43,7 @@
 
         <hr *ngIf="!last && initiative?.vacancies[roleIndex +1]" class="role-divider my-1">
     </ng-container>
-  </div> 
+  </div>
 
   <p class="text-muted small my-2">
     See all vacancies in the

--- a/apps/maptio/src/assets/styles/custom/global.css
+++ b/apps/maptio/src/assets/styles/custom/global.css
@@ -416,7 +416,7 @@ button.cursor-not-allowed{
 
 
 
-.btn-link, a:not(.btn-tag):not(.text-white):not(.text-success):not(.nav-link) {
+.btn-link, a:not(.btn-tag):not(.text-white):not(.text-gray-light):not(.text-success):not(.nav-link) {
   color: var(--maptio-blue) !important;
 }
 


### PR DESCRIPTION
### Issue
Closes #707 

### Description
See the issue for more context. In short, this implements these two tooltips:
![Screenshot 2022-05-12 at 22 03 31](https://user-images.githubusercontent.com/4092165/168288050-d3dcaf95-ec6b-4bc8-83b9-7ac160d7fa82.png)
![Screenshot 2022-05-12 at 22 01 00](https://user-images.githubusercontent.com/4092165/168288061-a99e70df-a4a1-4971-9290-cc9260f7deab.png)

I also made the labels on the table listing all people in an organisation have a style more consistent with other parts of the app.
