### PR TITLE
Close circle details without scrolling and improve panel scrollbars

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -1,4 +1,4 @@
-<div class="h-100 overflow-y pt-3">
+<div class="h-100 pt-3">
   <maptio-onboarding-message
     [messageKey]="'showEditingPanelMessage'"
   >

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
@@ -52,3 +52,33 @@
   border-radius: 1rem;
 }
 
+.clean-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.1);
+  border-radius: 0.25rem;
+}
+
+.clean-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(0, 0, 0, 0.25);
+  border-radius: 0.25rem;
+}
+
+.clean-scrollbar::-webkit-scrollbar-track {
+  background-color: transparent;
+}
+
+.clean-scrollbar::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.clean-scrollbar {
+  overflow-y: overlay;
+
+  -ms-overflow-style: auto;
+  scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+  scrollbar-width: thin;
+}
+
+.clean-scrollbar:hover {
+  scrollbar-color: rgba(0, 0, 0, 0.25) transparent;
+}

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
@@ -44,3 +44,11 @@
     width:66%;
     transition:all 1s;
 }
+
+.clean-close-button {
+  top: 0.5rem;
+  right: 0.5rem;
+  background-color: rgba(255,255,255,0.75) !important;
+  border-radius: 1rem;
+}
+

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
@@ -50,6 +50,7 @@
   right: 0.5rem;
   background-color: rgba(255,255,255,0.75) !important;
   border-radius: 1rem;
+  z-index: 1;
 }
 
 .clean-scrollbar::-webkit-scrollbar-thumb {

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
@@ -46,11 +46,17 @@
 }
 
 .clean-close-button {
-  top: 0.25rem;
-  right: 0.25rem;
-  padding: 3px 9px 3px 10px; /* With icon achieves a 32px by 32px button */
+  /* Position adjusted to look good both with and without scrollbar */
+  top: 4px;
+  right: 7px;
+
+  /* With icon achieves a 26px by 26px button */
+  padding: 0 6px 0 7px;
+
+  /* Match bootstrap button styles */
   border-radius: 0.25rem;
-  background-color: rgba(255,255,255,0.25) !important;
+
+  background-color: transparent !important;
   z-index: 1;
 }
 

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
@@ -1,10 +1,10 @@
 .saving{
-	opacity: 0.75;	
+	opacity: 0.75;
     transition-delay:0s;
 }
 
 .saving.hide{
-	opacity: 0;	
+	opacity: 0;
     transition: opacity 2s ease;
     transition-delay:2s;
 }
@@ -46,11 +46,26 @@
 }
 
 .clean-close-button {
-  top: 0.5rem;
-  right: 0.5rem;
-  background-color: rgba(255,255,255,0.75) !important;
-  border-radius: 1rem;
+  top: 0.25rem;
+  right: 0.25rem;
+  padding: 3px 9px 3px 10px; /* With icon achieves a 32px by 32px button */
+  border-radius: 0.25rem;
+  background-color: rgba(255,255,255,0.25) !important;
   z-index: 1;
+}
+
+.clean-close-button:hover {
+  color:rgba(0, 0, 0, 0.75);
+  background-color: rgba(255,255,255,0.75) !important;
+}
+
+.clean-close-button__icon {
+  color:rgba(0, 0, 0, 0.35);
+  transition: color .15s ease-in-out;
+}
+
+.clean-close-button:hover .clean-close-button__icon {
+  color:rgba(0, 0, 0, 0.75);
 }
 
 .clean-scrollbar::-webkit-scrollbar-thumb {

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
@@ -81,7 +81,7 @@
         class="position-relative d-none d-md-block collapsible bg-white details h-100 justify-content-start"
       >
         <button
-          class="clean-close-button position-absolute btn bg-transparent z-index-1"
+          class="clean-close-button position-absolute btn bg-transparent"
           [class.invisible]="isDetailsPanelCollapsed"
           (click)="closeDetailsPanel()"
         >

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
@@ -49,6 +49,7 @@
           class="hierarchy w-100 h-100 card border-light border-right bg-white"
         >
           <div class="card border-0 bg-transparent h-100">
+            <!-- The close button! -->
             <button
               class="position-absolute top-right btn bg-transparent"
               [class.invisible]="isBuildingPanelCollapsed"
@@ -78,20 +79,20 @@
         [ngClass]="{
           'show border-right': !isDetailsPanelCollapsed && isBuildingVisible
         }"
-        class="d-none d-md-block collapsible bg-white details h-100 justify-content-start overflow-y"
+        class="position-relative d-none d-md-block collapsible bg-white details h-100 justify-content-start"
       >
-        <div id="sidenav-details" class="h-100 w-100">
-          <div class="card border-0 bg-transparent">
-            <button
-              class="position-absolute top-right btn bg-transparent"
-              [class.invisible]="isDetailsPanelCollapsed"
-              (click)="closeDetailsPanel()"
-            >
-              <span aria-hidden="true" class="text-muted">
-                <i class="fas fa-times"></i>
-              </span>
-            </button>
+        <button
+          class="clean-close-button position-absolute btn bg-transparent z-index-1"
+          [class.invisible]="isDetailsPanelCollapsed"
+          (click)="closeDetailsPanel()"
+        >
+          <span aria-hidden="true" class="text-muted">
+            <i class="fas fa-times"></i>
+          </span>
+        </button>
 
+        <div id="sidenav-details" class="h-100 w-100 overflow-y">
+          <div class="card border-0 bg-transparent">
             <div class="card-body p-3 pt-4">
               <initiative
                 *ngIf="!isDetailsPanelCollapsed"

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
@@ -53,7 +53,7 @@
             [class.invisible]="isBuildingPanelCollapsed"
             (click)="closeBuildingPanel()"
           >
-            <span aria-hidden="true" class="text-muted">
+            <span aria-hidden="true" class="clean-close-button__icon">
               <i class="fas fa-times"></i>
             </span>
           </button>
@@ -85,7 +85,7 @@
           [class.invisible]="isDetailsPanelCollapsed"
           (click)="closeDetailsPanel()"
         >
-          <span aria-hidden="true" class="text-muted">
+          <span aria-hidden="true" class="clean-close-button__icon">
             <i class="fas fa-times"></i>
           </span>
         </button>

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
@@ -91,7 +91,7 @@
           </span>
         </button>
 
-        <div id="sidenav-details" class="h-100 w-100 overflow-y">
+        <div id="sidenav-details" class="h-100 w-100 clean-scrollbar">
           <div class="card border-0 bg-transparent">
             <div class="card-body p-3 pt-4">
               <initiative

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
@@ -48,18 +48,17 @@
           id="sidenav-hierarchy"
           class="hierarchy w-100 h-100 card border-light border-right bg-white"
         >
-          <div class="card border-0 bg-transparent h-100">
-            <!-- The close button! -->
-            <button
-              class="position-absolute top-right btn bg-transparent"
-              [class.invisible]="isBuildingPanelCollapsed"
-              (click)="closeBuildingPanel()"
-            >
-              <span aria-hidden="true" class="text-muted">
-                <i class="fas fa-times"></i>
-              </span>
-            </button>
+          <button
+            class="clean-close-button position-absolute top-right btn bg-transparent"
+            [class.invisible]="isBuildingPanelCollapsed"
+            (click)="closeBuildingPanel()"
+          >
+            <span aria-hidden="true" class="text-muted">
+              <i class="fas fa-times"></i>
+            </span>
+          </button>
 
+          <div class="clean-scrollbar card border-0 bg-transparent h-100">
             <div class="card-body h-100 p-3">
               <building
                 #building


### PR DESCRIPTION
### Issue
Fixes #689 

### Description
The main purpose of this was to address #689 (see description there) and, possibly, make the x seem less like it might be closing the onboarding messages. In the process of experimenting with the different options, I ended up also improving the scrollbars and very subtly changing the design of the button to make it overlay content a bit better. Some highlights below.

### Before
![Screenshot 2022-05-19 at 19 21 24](https://user-images.githubusercontent.com/4092165/169373106-91a579c4-90d3-45f2-bfa8-1402b33cf1bf.png)

and then when the scrollbar handle finishes, we've still got the tracks:
![Screenshot 2022-05-19 at 19 26 13](https://user-images.githubusercontent.com/4092165/169373521-6468d211-0620-4169-bd66-899f7a5f15cd.png)


### After
![Screenshot 2022-05-19 at 19 21 38](https://user-images.githubusercontent.com/4092165/169373135-5504bec4-3479-427c-8f47-66e037c0855f.png)

![Screenshot 2022-05-19 at 19 22 00](https://user-images.githubusercontent.com/4092165/169373145-db449f3d-ea18-4674-9d30-b5a6d7412225.png)

and then when the scrollbar handle finishes, there's nothing but content:
![Screenshot 2022-05-19 at 19 26 05](https://user-images.githubusercontent.com/4092165/169373552-754f2847-d358-4a1c-a038-2776fdd06dd6.png)

and, finally, you can close the side panel even after scrolling - and subtle hover effects communicate that you're closing the side panel rather than clicking on the content:
![Screenshot 2022-05-19 at 19 29 57](https://user-images.githubusercontent.com/4092165/169374556-369357f3-fdc8-4838-b0e9-53b479983fe2.png)