### PR TITLE
Fix broken scrolling in Firefox

### DIFF
--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.css
@@ -94,6 +94,7 @@
 }
 
 .clean-scrollbar {
+  overflow-y: auto; /* For Firefox, and anywhere `overlay` isn't supported */
   overflow-y: overlay;
 
   -ms-overflow-style: auto;


### PR DESCRIPTION
### Issue
Follow up to #715 

### Description
The implementation of #715 used `overflow-y: overlay` which is not supported in Firefox. Added `auto` for Firefox and other browsers that don't support `overlay`.