### PR TITLE
Hide edit map bar completely in directory

### DIFF
--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html
@@ -19,11 +19,11 @@
     >
       <div
         id="toggle"
-        class="d-none d-md-flex h-100 rounded-left py-3 flex-shrink-0 flex-column justify-content-start align-items-center cursor-pointer collapsible"
+        class="d-none h-100 rounded-left py-3 flex-shrink-0 flex-column justify-content-start align-items-center cursor-pointer collapsible"
         [class.hide]="!isBuildingPanelCollapsed"
         [class.show]="isBuildingPanelCollapsed"
-        [ngClass]="{ 'bg-accent-gray pointer-none': !isBuildingVisible }"
         [class.bg-accent]="isBuildingVisible"
+        [class.d-md-flex]="isBuildingVisible"
         (click)="openBuildingPanel()"
       >
         <div

--- a/apps/maptio/src/assets/styles/custom/angular-tree-component.css
+++ b/apps/maptio/src/assets/styles/custom/angular-tree-component.css
@@ -110,6 +110,9 @@ tree-viewport {
 }
 
 .angular-tree-component {
+  /* Fix to improve styles in Safari with the clean scrollbar class */
+  overflow-y: hidden;
+
   width: 100%;
   position: relative;
   display: inline-block;
@@ -177,7 +180,7 @@ tree-root .angular-tree-component-rtl .tree-children {
   position: relative;
   width: 100%;
   padding: 2px 0px !important;
-  margin-left: 0.5vw; 
+  margin-left: 0.5vw;
   /* margin-right: 0.5vw; */
 }
 


### PR DESCRIPTION
### Description
A couple of small UI tweaks, mainly "Make the "edit map" bar disappear in the directory view" (from [self-service onboarding spreadsheet](https://docs.google.com/spreadsheets/d/1b5sR4QRbDaIPtE4rLGatkQM48WXHvoG_uyArHA_3Ikg/edit#gid=0&range=E28)) and making an angular tree scrollbar disappear (it was only visible in Safari, but still).
