### PR TITLE
Prevent duplicate maps creation during onboarding

### DIFF
--- a/apps/maptio/src/app/shared/components/modal/modal.component.html
+++ b/apps/maptio/src/app/shared/components/modal/modal.component.html
@@ -22,7 +22,7 @@
         </div>
     </div>
     <div class="d-flex justify-content-end col-12 col-md mt-3 mt-md-0">
-        <button type="button" class="btn btn-lg btn-outline-secondary mx-1" [class.invisible]="!previousActionName" (click)="previousStep()">{{previousActionName}}</button>
+        <button type="button" class="btn btn-lg btn-outline-secondary mx-1" [class.invisible]="!previousActionName" [disabled]="isUpdating" (click)="previousStep()">{{previousActionName}}</button>
         <button type="button" *ngIf="isSkippable" class="btn btn-lg btn-link mx-1" (click)="nextStep()">I'll do this later</button>
         <button type="button" *ngIf="!isSkippable" class="btn btn-lg btn-success" [class.invisible]="!nextActionName" [disabled]="isUpdating" (click)="nextStep()">
           <i *ngIf="isUpdating" class="fas fa-circle-notch fa-spin"></i>

--- a/apps/maptio/src/app/shared/components/modal/modal.component.html
+++ b/apps/maptio/src/app/shared/components/modal/modal.component.html
@@ -24,6 +24,9 @@
     <div class="d-flex justify-content-end col-12 col-md mt-3 mt-md-0">
         <button type="button" class="btn btn-lg btn-outline-secondary mx-1" [class.invisible]="!previousActionName" (click)="previousStep()">{{previousActionName}}</button>
         <button type="button" *ngIf="isSkippable" class="btn btn-lg btn-link mx-1" (click)="nextStep()">I'll do this later</button>
-        <button type="button" *ngIf="!isSkippable" class="btn btn-lg btn-success" [class.invisible]="!nextActionName" (click)="nextStep()">{{nextActionName}}</button>
+        <button type="button" *ngIf="!isSkippable" class="btn btn-lg btn-success" [class.invisible]="!nextActionName" [disabled]="isUpdating" (click)="nextStep()">
+          <i *ngIf="isUpdating" class="fas fa-circle-notch fa-spin"></i>
+          {{nextActionName}}
+        </button>
     </div>
 </div>

--- a/apps/maptio/src/app/shared/components/modal/modal.component.ts
+++ b/apps/maptio/src/app/shared/components/modal/modal.component.ts
@@ -14,6 +14,7 @@ export class CommonModalComponent implements OnInit {
     @Input("isReady") isReady: boolean;
     @Input("isClosable") isClosable:boolean;
     @Input("isWithProgress") isWithProgress: boolean;
+    @Input() isUpdating = false;
     @Input("progress") progress: string;
     @Input("progressLabel") progressLabel: string;
 

--- a/apps/maptio/src/app/shared/components/onboarding/onboarding.component.html
+++ b/apps/maptio/src/app/shared/components/onboarding/onboarding.component.html
@@ -1,6 +1,7 @@
 <common-modal [nextActionName]="nextActionName" [previousActionName]="previousActionName" [isSkippable]="isSkippable"
     [isReady]="true" [isWithProgress]="true" [isWithProgress]="false" [progress]="progress"
-    [progressLabel]="progressLabel" (next)="nextStep()" (previous)="previousStep()">
+    [progressLabel]="progressLabel" [isUpdating]="isCreatingTeam || isCreatingMap"
+    (next)="nextStep()" (previous)="previousStep()">
 
     <ng-container *ngIf="currentStep === 'Welcome'">
         <ng-container *ngTemplateOutlet="welcome"></ng-container>
@@ -59,8 +60,6 @@
         <div class="form-row w-100 d-flex justify-content-center align-items-center flex-column">
             <input [(ngModel)]="team.name" type="text" class="form-control col-12 col-md-10 col-lg-6">
             <small *ngIf="teamCreationErrorMessage" class="form-text text-danger">{{teamCreationErrorMessage}}</small>
-            <small *ngIf="isCreatingTeam" class="text-green">
-                <i class="fas fa-circle-notch fa-spin"></i> Setting up your organisation</small>
         </div>
     </div>
 

--- a/apps/maptio/src/app/shared/components/onboarding/onboarding.component.html
+++ b/apps/maptio/src/app/shared/components/onboarding/onboarding.component.html
@@ -21,7 +21,7 @@
         <span class="text-accent">👋 {{user?.firstname}}</span>, your first map is just a few clicks away!
     </ng-template>
     <ng-template #guide>
-        Let's set up your organization. It will only take a minute.
+        Let's set up your organisation. It will only take a minute.
     </ng-template>
 
 
@@ -76,7 +76,7 @@
 
     <ng-template #settingsnote>
         <span class="text-muted">
-            You can always change this later in the organization settings.
+            You can always change this later in the organisation settings.
         </span>
     </ng-template>
 

--- a/apps/maptio/src/app/shared/components/onboarding/onboarding.component.ts
+++ b/apps/maptio/src/app/shared/components/onboarding/onboarding.component.ts
@@ -44,7 +44,9 @@ export class OnboardingComponent implements OnInit {
     ]
     selectedColor: string = this.COLORS[0].name;
     mapName: string;
+
     isCreatingTeam: boolean;
+    isCreatingMap = false;
 
     members: User[];
     team: Team;
@@ -87,23 +89,28 @@ export class OnboardingComponent implements OnInit {
     }
 
     nextStep() {
+        if (this.isCreatingTeam || this.isCreatingMap) {
+          return;
+        }
 
         if (this.currentStep === "CreateTeam") {
             this.isCreatingTeam = false;
             this.cd.markForCheck();
             if (isEmpty(this.team.name)) {
                 this.teamCreationErrorMessage = "We need a name to continue."
+                this.nextActionName = 'Next';
                 this.cd.markForCheck();
                 return;
             }
             else {
                 this.isCreatingTeam = true;
+                this.nextActionName = 'Setting up your organisation';
+                this.teamCreationErrorMessage = null;
                 this.cd.markForCheck();
                 this.saveTeam(this.team)
                     .then(team => {
                         this.isCreatingTeam = false;
                         this.team = team;
-                        this.teamCreationErrorMessage = null;
                         this.mapName = `${team.name} map`
                         this.goToNextStep();
                         this.cd.markForCheck();
@@ -112,6 +119,9 @@ export class OnboardingComponent implements OnInit {
         }
         else if (this.currentStep === "Terminology") {
             this.sendOnboardingEventToMixpanel();
+
+            this.isCreatingMap = true;
+            this.nextActionName = 'Creating your map';
 
             return this.createMap(this.mapName)
                 .then(dataset => {
@@ -145,7 +155,6 @@ export class OnboardingComponent implements OnInit {
     private goToNextStep() {
         this.currentIndex += 1;
         this.currentStep = this.steps[this.currentIndex]
-        console.log('current step', this.currentStep);
         this.nextActionName = this.getNextActionName();
         this.previousActionName = this.getPreviousActionName();
         this.isClosable = this.getIsClosable();


### PR DESCRIPTION
### Description
From [self-service onboarding spreadsheet](https://docs.google.com/spreadsheets/d/1b5sR4QRbDaIPtE4rLGatkQM48WXHvoG_uyArHA_3Ikg/edit#gid=0&range=E35):
(I think I've mentioned this before, but it came up so I'm highlighting just in case). In the onboarding flow, right at the last stage when they clicked the final button which then creates the map, there's a bit of a delay where there's no feedback. The user clicked the button again and Maptio ended up creating two maps. Perhaps on click the button should change to "Creating your map, please wait" and be disabled so it can't be clicked again. Or some other similar pattern - whatever's easiest to avoid 2 maps being created.