### PR TITLE
Close circle details when opening new map

### DIFF
--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
@@ -89,8 +89,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
           if (newDatasetId !== this.datasetId) {
             this.isBuildingPanelCollapsed = false;
             this.isDetailsPanelCollapsed = true;
-            // this.closeDetailsPanel();
-            // this.closeBuildingPanel();
             this.cd.markForCheck();
           }
         }),
@@ -103,6 +101,12 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
             return this.buildingComponent
               .loadData(data.data.dataset, data.data.team, data.data.members)
               .then(() => {
+                console.log('Will be closing details panel in 100ms...');
+                setTimeout(() => {
+                  console.log('...and closing now.');
+                  this.closeDetailsPanel();
+                }, 100);
+                console.time();
                 this.isLoading = false;
                 this.cd.markForCheck();
               });
@@ -240,6 +244,8 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   openDetailsPanel() {
+    console.timeEnd();
+    console.log('open details panel');
     this.isDetailsPanelCollapsed = false;
     // this.resizeMap();
     this.cd.markForCheck();

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
@@ -101,12 +101,12 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
             return this.buildingComponent
               .loadData(data.data.dataset, data.data.team, data.data.members)
               .then(() => {
-                console.log('Will be closing details panel in 100ms...');
+                // Hack to make sure the circle details panel stays closed...
+                // TODO: Remove this when we've got good enough state
+                // management here
                 setTimeout(() => {
-                  console.log('...and closing now.');
                   this.closeDetailsPanel();
                 }, 100);
-                console.time();
                 this.isLoading = false;
                 this.cd.markForCheck();
               });
@@ -244,8 +244,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   }
 
   openDetailsPanel() {
-    console.timeEnd();
-    console.log('open details panel');
     this.isDetailsPanelCollapsed = false;
     // this.resizeMap();
     this.cd.markForCheck();


### PR DESCRIPTION
### Description
Bad news: this is a dreadful, dreadful hack to avoid digging through state management and still be able to avoid the even more dreadful, potentially data-loss-inducing bug that was caused by panel with old circle details data staying open after you opened a new map.

Good news: We agreed to fix the workspace state management soon - and then overall state management in the app, yay!

Good news: The hack means we don't need to add warning messages that we planned in case no quick hack was available to us.

From the [self-service onboarding spreadsheet](https://docs.google.com/spreadsheets/d/1b5sR4QRbDaIPtE4rLGatkQM48WXHvoG_uyArHA_3Ikg/edit#gid=0&range=E41):
> State management for when you create a second map or switch between maps - when the circle details stay open - add a message (Please refresh) when you click the "create" button and ask the user to confirm