### PR TITLE
Disable Logrocket and Mixpanel

### DIFF
--- a/apps/maptio/src/app/core/analytics.module.ts
+++ b/apps/maptio/src/app/core/analytics.module.ts
@@ -28,16 +28,16 @@ import * as LogRocket from "logrocket";
 export class AnalyticsModule {
     constructor(mixpanel: Angulartics2Mixpanel) {
 
-        if (!isDevMode()) {
-            LogRocket.init(environment.LOGROCKET_APP_ID, {
-                network: {
-                    isEnabled: true
-                }
+        // if (!isDevMode()) {
+        //     LogRocket.init(environment.LOGROCKET_APP_ID, {
+        //         network: {
+        //             isEnabled: true
+        //         }
 
-            });
-            mixpanel.startTracking()
-        }
-        
+        //     });
+        //     mixpanel.startTracking()
+        // }
+
     }
 
 }


### PR DESCRIPTION
Noticed massive slowdowns in production and tracked this down to requests to logrocket, how weird! Deploying this to disable logrocket (as we should anyway) and see whether that fixes the issue.
