### PR TITLE
Make tree icons more intuitive

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -84,6 +84,23 @@
 </div>
 
 
+<ng-template #deleteConfirmation let-c="close" let-d="dismiss">
+	<div class="modal-body">
+		<h1>Are you sure?</h1>
+    <p>To be or not to be...</p>
+		<!-- <p>
+			Circle
+			<b>{{fromInitiative.name}}</b> and it sub-circles will be moved under
+			<b>{{toInitiative.name}}</b>
+		</p> -->
+	</div>
+
+	<div class="modal-footer">
+		<button type="button" class="btn btn-link" (click)="c(false)">No</button>
+		<button type="button" class="btn btn-danger" (click)="c(true)">Delete circle</button>
+	</div>
+</ng-template>
+
 <ng-template #dragConfirmation let-c="close" let-d="dismiss">
 	<div class="modal-body">
 		<h1>Are you sure?</h1>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -17,13 +17,13 @@
 			<ng-template ngbNavContent>
 				<div class=" d-flex flex-column">
 					<div class="card mb-3 w-100 border-0 bg-transparent">
-						<div class="card-body px-0">
+						<div class="card-body px-0 pb-1 pt-4 align-self-center">
 							<button name="" id="" class="btn btn-outline-secondary" (click)="!isToggling && toggleAll(true)" role="button">
-								<i class="fas" [class.fa-plus-circle]="!isExpanding" [class.fa-circle-notch]="isExpanding" [class.fa-spin]="isExpanding"
+								<i class="fas mr-1" [class.fa-angle-double-down]="!isExpanding" [class.fa-circle-notch]="isExpanding" [class.fa-spin]="isExpanding"
 								 aria-hidden="true"></i> Expand all
 							</button>
 							<button name="" id="" class="btn btn-outline-secondary mx-2" (click)="!isToggling && toggleAll(false)" role="button">
-								<i class="fas" [class.fa-minus-circle]="!isCollapsing" [class.fa-circle-notch]="isCollapsing" [class.fa-spin]="isCollapsing"
+								<i class="fas mr-1" [class.fa-angle-double-up]="!isCollapsing" [class.fa-circle-notch]="isCollapsing" [class.fa-spin]="isCollapsing"
 								 aria-hidden="true"></i> Collapse all
 							</button>
 

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -87,16 +87,24 @@
 <ng-template #deleteConfirmation let-c="close" let-d="dismiss">
 	<div class="modal-body">
 		<h1>Are you sure?</h1>
-    <p>To be or not to be...</p>
-		<!-- <p>
-			Circle
-			<b>{{fromInitiative.name}}</b> and it sub-circles will be moved under
-			<b>{{toInitiative.name}}</b>
-		</p> -->
+
+    <div
+      class="alert alert-danger"
+      role="alert"
+    >
+      <i class="fas fa-exclamation-triangle"></i>
+      This cannot be undone.
+    </div>
+
+    <p class="mb-0">
+      Circle
+      <b>{{initiativeToBeDeleted.name}}</b> will be deleted
+      <b>along with its sub-circles</b>.
+    </p>
 	</div>
 
 	<div class="modal-footer">
-		<button type="button" class="btn btn-link" (click)="c(false)">No</button>
+		<button type="button" class="btn btn-link" (click)="c(false)">Cancel</button>
 		<button type="button" class="btn btn-danger" (click)="c(true)">Delete circle</button>
 	</div>
 </ng-template>
@@ -106,7 +114,7 @@
 		<h1>Are you sure?</h1>
 		<p>
 			Circle
-			<b>{{fromInitiative.name}}</b> and it sub-circles will be moved under
+			<b>{{fromInitiative.name}}</b> and its sub-circles will be moved under
 			<b>{{toInitiative.name}}</b>
 		</p>
 	</div>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -53,8 +53,17 @@
 					<div>
 						<tree-root #tree [nodes]="nodes" (updateData)="saveChanges()" [options]="options" [state]="state" (stateChange)="setState($event)">
 							<ng-template #treeNodeTemplate let-node let-index="index">
-								<initiative-node [node]="node" [datasetId]="datasetId" [team]="team" [user]="user" (edited)="saveChanges()" (update)="updateTreeModel(tree.treeModel)"
-								 (open)="openNodeDetails($event)" (add)="openNodeDetails($event)"></initiative-node>
+								<initiative-node
+                  [node]="node"
+                  [datasetId]="datasetId"
+                  [team]="team"
+                  [user]="user"
+                  (edited)="saveChanges()"
+                  (update)="updateTreeModel(tree.treeModel)"
+								  (open)="openNodeDetails($event)"
+                  (add)="openNodeDetails($event)"
+                  (delete)="onDeleteNode($event)"
+                ></initiative-node>
 							</ng-template>
 						</tree-root>
 					</div>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -247,11 +247,27 @@ export class BuildingComponent implements OnDestroy {
         this.saveChanges();
     }
 
+    onDeleteNode(initiative: Initiative) {
+      this.modalService
+        .open(this.dragConfirmationModal, { centered: true })
+        .result
+        .then(result => {
+          if (result) {
+            console.log('deleting initiative', initiative);
+            this.removeNode(initiative);
+          } else {
+            console.log('not deleting initiative after all');
+          }
+        })
+        .catch(reason => {
+          console.error(reason);
+        });
+    }
+
     moveNode(node: Initiative, from: Initiative, to: Initiative) {
         let foundTreeNode = this.tree.treeModel.getNodeById(node.id)
         let foundToNode = this.tree.treeModel.getNodeById(to.id);
         TREE_ACTIONS.MOVE_NODE(this.tree.treeModel, foundToNode, {}, { from: foundTreeNode, to: { parent: foundToNode } })
-
     }
 
     removeNode(node: Initiative) {

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -324,9 +324,15 @@ export class BuildingComponent implements OnDestroy {
             isExpand
                 ? this.tree.treeModel.expandAll()
                 : this.tree.treeModel.collapseAll();
+
+            // This is handled in setState already... but that doesn't fire
+            // the tree is already expanded, effectively breaking the
+            // expand/collapse all buttons - so we repeat this here
+            this.isCollapsing = false;
+            this.isExpanding = false;
+            this.isToggling = false;
+            this.cd.markForCheck();
         }, 100);
-
-
     }
 
     /**

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -35,8 +35,6 @@ export class BuildingComponent implements OnDestroy {
     searched: string;
     nodes: Array<Initiative>;
 
-    fromInitiative: Initiative;
-    toInitiative: Initiative;
 
 
     options = {
@@ -102,9 +100,12 @@ export class BuildingComponent implements OnDestroy {
 
     @ViewChild("deleteConfirmation", { static: true })
     deleteConfirmationModal: NgbModal;
+    fromInitiative: Initiative;
+    toInitiative: Initiative;
 
     @ViewChild("dragConfirmation", { static: true })
     dragConfirmationModal: NgbModal;
+    initiativeToBeDeleted: Initiative;
 
     datasetId: string;
 
@@ -251,20 +252,17 @@ export class BuildingComponent implements OnDestroy {
     }
 
     onDeleteNode(initiative: Initiative) {
+      this.initiativeToBeDeleted = initiative;
+
       this.modalService
         .open(this.deleteConfirmationModal, { centered: true })
         .result
         .then(result => {
           if (result) {
-            console.log('deleting initiative', initiative);
             this.removeNode(initiative);
-          } else {
-            console.log('not deleting initiative after all');
           }
         })
-        .catch(reason => {
-          console.error(reason);
-        });
+        .catch();
     }
 
     moveNode(node: Initiative, from: Initiative, to: Initiative) {

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -100,6 +100,9 @@ export class BuildingComponent implements OnDestroy {
     @ViewChild(InitiativeNodeComponent)
     node: InitiativeNodeComponent;
 
+    @ViewChild("deleteConfirmation", { static: true })
+    deleteConfirmationModal: NgbModal;
+
     @ViewChild("dragConfirmation", { static: true })
     dragConfirmationModal: NgbModal;
 
@@ -249,7 +252,7 @@ export class BuildingComponent implements OnDestroy {
 
     onDeleteNode(initiative: Initiative) {
       this.modalService
-        .open(this.dragConfirmationModal, { centered: true })
+        .open(this.deleteConfirmationModal, { centered: true })
         .result
         .then(result => {
           if (result) {

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
@@ -59,10 +59,23 @@
 
 			</div>
 			<ng-template #thenDeleteBlock>
-				<button class="btn remove border border-left-0  btn-outline-secondary" placement="top" container="body" mwlConfirmationPopover
-				 [popoverMessage]="'Remove circle and sub-circles ?'" focusbutton="cancel" appendToBody="false" (confirm)="removeChildNode(node.data)"
-				 (cancel)="cancelClicked = true" angularticsEvent="Map" [angularticsProperties]="{mode: 'list', action:'remove', team:teamName, teamId:teamId }"
-				 angulartics2On="click"></button>
+				<button
+          (click)="onDeleteNode(node.data)"
+          class="btn remove border border-left-0  btn-outline-secondary"
+
+          placement="top"
+          container="body"
+          mwlConfirmationPopover
+				  [popoverMessage]="'Remove circle and sub-circles ?'"
+          focusbutton="cancel"
+          appendToBody="false"
+          (confirm)="removeChildNode(node.data)"
+				  (cancel)="cancelClicked = true"
+
+          angularticsEvent="Map"
+          [angularticsProperties]="{mode: 'list', action:'remove', team:teamName, teamId:teamId }"
+				  angulartics2On="click"
+        ></button>
 
 			</ng-template>
 			<ng-template #elseDeleteBlock>
@@ -87,7 +100,7 @@
 			<ng-container *ngTemplateOutlet="nodeEditing"></ng-container>
 
 		</div>
-		
+
 	</ng-template>
 	<ng-template #elseMoveBlock>
 		<div class="input-group rounded" >
@@ -99,7 +112,7 @@
 			<ng-container *ngTemplateOutlet="nodeEditing"></ng-container>
 
 		</div>
-		
+
 
 	</ng-template>
 

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
@@ -62,16 +62,6 @@
 				<button
           (click)="onDeleteNode(node.data)"
           class="btn remove border border-left-0  btn-outline-secondary"
-
-          placement="top"
-          container="body"
-          mwlConfirmationPopover
-				  [popoverMessage]="'Remove circle and sub-circles ?'"
-          focusbutton="cancel"
-          appendToBody="false"
-          (confirm)="removeChildNode(node.data)"
-				  (cancel)="cancelClicked = true"
-
           angularticsEvent="Map"
           [angularticsProperties]="{mode: 'list', action:'remove', team:teamName, teamId:teamId }"
 				  angulartics2On="click"

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
@@ -30,6 +30,7 @@ export class InitiativeNodeComponent {
     @Output("update") updateTreeEvent = new EventEmitter<TreeModel>();
     @Output("open") open = new EventEmitter<Initiative>();
     @Output("add") add = new EventEmitter<Initiative>();
+    @Output() delete = new EventEmitter<Initiative>();
 
     @ViewChild("initiative") editInitiative: InitiativeComponent;
 
@@ -112,6 +113,9 @@ export class InitiativeNodeComponent {
         this.add.emit(newNode);
     }
 
+    onDeleteNode(initiative: Initiative) {
+      this.delete.emit(initiative);
+    }
 
     removeChildNode(initiative: Initiative) {
         this.node.treeModel.getNodeById(initiative.id).data.children = [];

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
@@ -117,18 +117,7 @@ export class InitiativeNodeComponent {
       this.delete.emit(initiative);
     }
 
-    removeChildNode(initiative: Initiative) {
-        this.node.treeModel.getNodeById(initiative.id).data.children = [];
-        let parent = this.node.treeModel.getNodeById(initiative.id).parent;
-        let index = parent.data.children.indexOf(initiative);
-        parent.data.children.splice(index, 1);
-        this.updateTreeEvent.emit(this.node.treeModel);
-        this.edited.emit(true)
-    }
-
     openNode(node: Initiative) {
         this.open.emit(node);
     }
-
-
 }

--- a/apps/maptio/src/app/modules/workspace/components/sharing/sharing.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/sharing/sharing.component.html
@@ -19,7 +19,10 @@
   <h3 class="editing-title">Public read-only embeddable map is enabled</h3>
   <p>
     This map can be viewed publicly at the following URL:
-    <a href="{{ shareableUrl }}">
+    <a
+      href="{{ shareableUrl }}"
+      class="text-break"
+    >
       {{ shareableUrl }}
     </a>
   </p>

--- a/apps/maptio/src/assets/styles/custom/angular-tree-component.css
+++ b/apps/maptio/src/assets/styles/custom/angular-tree-component.css
@@ -147,31 +147,30 @@ tree-root .angular-tree-component-rtl .tree-children {
 
 
 .toggle-children {
-  top: 11px !important;
+  top: 9px !important;
   background-image: none !important;
   transform: rotate(0deg) !important;
   width: 6px !important;
 }
 
 .toggle-children:before {
-  color: var(--maptio-accent);
+  color: #6c757d !important;
   transform: rotate(0deg) !important;
   font-family: FontAwesome;
   font-size: 17px;
 }
 
 .toggle-children-wrapper-expanded >  .toggle-children:before {
+  content: "\f078";
+  padding-top: 0.25rem;
   font-family: "Font Awesome 5 Free";
-
   font-weight: bold;
-  content: "\f056";
 }
 
 .toggle-children-wrapper-collapsed > .toggle-children:before {
-  content: "\f055";
+  content: "\f054";
   font-family: "Font Awesome 5 Free";
   font-weight: bold;
-
 }
 
 


### PR DESCRIPTION
### Description
From [self-service onboarding spreadsheet](https://docs.google.com/spreadsheets/d/1b5sR4QRbDaIPtE4rLGatkQM48WXHvoG_uyArHA_3Ikg/edit#gid=0&range=E16):
> In the list view, differentiate between Change the add sub-circle icon (currently a +) to something else (perhaps a circle with a small + in the top-right corner)

The idea is to make it clearer what the icons do. Instead of changing the "plus" button into a "circle with a plus", I've changed it to what feels more "best practice-y" - the plus icon does feel intuitive - i.e. this is what you'd expect to add something. But the expanding and collapsing icons are normally chevrons, so I used those.

I've also changed the "expand/collapse all" button icons and tweaked the spacing.

In pictures, this is what we had before:
![Screenshot 2022-06-01 at 11 43 45](https://user-images.githubusercontent.com/4092165/171386825-fc01de97-a2a8-47fc-b66b-85f43860c22e.png)

This is what we have now:
![Screenshot 2022-06-01 at 09 06 12](https://user-images.githubusercontent.com/4092165/171386861-7cda02ee-85a5-44f6-a045-a3d611ddfc5d.png)

