### PR TITLE
Make it harder to dismiss circle deletion warnings

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -84,6 +84,23 @@
 </div>
 
 
+<ng-template #deleteConfirmation let-c="close" let-d="dismiss">
+	<div class="modal-body">
+		<h1>Are you sure?</h1>
+    <p>To be or not to be...</p>
+		<!-- <p>
+			Circle
+			<b>{{fromInitiative.name}}</b> and it sub-circles will be moved under
+			<b>{{toInitiative.name}}</b>
+		</p> -->
+	</div>
+
+	<div class="modal-footer">
+		<button type="button" class="btn btn-link" (click)="c(false)">No</button>
+		<button type="button" class="btn btn-danger" (click)="c(true)">Delete circle</button>
+	</div>
+</ng-template>
+
 <ng-template #dragConfirmation let-c="close" let-d="dismiss">
 	<div class="modal-body">
 		<h1>Are you sure?</h1>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -87,16 +87,24 @@
 <ng-template #deleteConfirmation let-c="close" let-d="dismiss">
 	<div class="modal-body">
 		<h1>Are you sure?</h1>
-    <p>To be or not to be...</p>
-		<!-- <p>
-			Circle
-			<b>{{fromInitiative.name}}</b> and it sub-circles will be moved under
-			<b>{{toInitiative.name}}</b>
-		</p> -->
+
+    <div
+      class="alert alert-danger"
+      role="alert"
+    >
+      <i class="fas fa-exclamation-triangle"></i>
+      This cannot be undone.
+    </div>
+
+    <p class="mb-0">
+      Circle
+      <b>{{initiativeToBeDeleted.name}}</b> will be deleted
+      <b>along with its sub-circles</b>.
+    </p>
 	</div>
 
 	<div class="modal-footer">
-		<button type="button" class="btn btn-link" (click)="c(false)">No</button>
+		<button type="button" class="btn btn-link" (click)="c(false)">Cancel</button>
 		<button type="button" class="btn btn-danger" (click)="c(true)">Delete circle</button>
 	</div>
 </ng-template>
@@ -106,7 +114,7 @@
 		<h1>Are you sure?</h1>
 		<p>
 			Circle
-			<b>{{fromInitiative.name}}</b> and it sub-circles will be moved under
+			<b>{{fromInitiative.name}}</b> and its sub-circles will be moved under
 			<b>{{toInitiative.name}}</b>
 		</p>
 	</div>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -53,8 +53,17 @@
 					<div>
 						<tree-root #tree [nodes]="nodes" (updateData)="saveChanges()" [options]="options" [state]="state" (stateChange)="setState($event)">
 							<ng-template #treeNodeTemplate let-node let-index="index">
-								<initiative-node [node]="node" [datasetId]="datasetId" [team]="team" [user]="user" (edited)="saveChanges()" (update)="updateTreeModel(tree.treeModel)"
-								 (open)="openNodeDetails($event)" (add)="openNodeDetails($event)"></initiative-node>
+								<initiative-node
+                  [node]="node"
+                  [datasetId]="datasetId"
+                  [team]="team"
+                  [user]="user"
+                  (edited)="saveChanges()"
+                  (update)="updateTreeModel(tree.treeModel)"
+								  (open)="openNodeDetails($event)"
+                  (add)="openNodeDetails($event)"
+                  (delete)="onDeleteNode($event)"
+                ></initiative-node>
 							</ng-template>
 						</tree-root>
 					</div>

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -247,11 +247,27 @@ export class BuildingComponent implements OnDestroy {
         this.saveChanges();
     }
 
+    onDeleteNode(initiative: Initiative) {
+      this.modalService
+        .open(this.dragConfirmationModal, { centered: true })
+        .result
+        .then(result => {
+          if (result) {
+            console.log('deleting initiative', initiative);
+            this.removeNode(initiative);
+          } else {
+            console.log('not deleting initiative after all');
+          }
+        })
+        .catch(reason => {
+          console.error(reason);
+        });
+    }
+
     moveNode(node: Initiative, from: Initiative, to: Initiative) {
         let foundTreeNode = this.tree.treeModel.getNodeById(node.id)
         let foundToNode = this.tree.treeModel.getNodeById(to.id);
         TREE_ACTIONS.MOVE_NODE(this.tree.treeModel, foundToNode, {}, { from: foundTreeNode, to: { parent: foundToNode } })
-
     }
 
     removeNode(node: Initiative) {

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -35,8 +35,6 @@ export class BuildingComponent implements OnDestroy {
     searched: string;
     nodes: Array<Initiative>;
 
-    fromInitiative: Initiative;
-    toInitiative: Initiative;
 
 
     options = {
@@ -102,9 +100,12 @@ export class BuildingComponent implements OnDestroy {
 
     @ViewChild("deleteConfirmation", { static: true })
     deleteConfirmationModal: NgbModal;
+    fromInitiative: Initiative;
+    toInitiative: Initiative;
 
     @ViewChild("dragConfirmation", { static: true })
     dragConfirmationModal: NgbModal;
+    initiativeToBeDeleted: Initiative;
 
     datasetId: string;
 
@@ -251,20 +252,17 @@ export class BuildingComponent implements OnDestroy {
     }
 
     onDeleteNode(initiative: Initiative) {
+      this.initiativeToBeDeleted = initiative;
+
       this.modalService
         .open(this.deleteConfirmationModal, { centered: true })
         .result
         .then(result => {
           if (result) {
-            console.log('deleting initiative', initiative);
             this.removeNode(initiative);
-          } else {
-            console.log('not deleting initiative after all');
           }
         })
-        .catch(reason => {
-          console.error(reason);
-        });
+        .catch();
     }
 
     moveNode(node: Initiative, from: Initiative, to: Initiative) {

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -100,6 +100,9 @@ export class BuildingComponent implements OnDestroy {
     @ViewChild(InitiativeNodeComponent)
     node: InitiativeNodeComponent;
 
+    @ViewChild("deleteConfirmation", { static: true })
+    deleteConfirmationModal: NgbModal;
+
     @ViewChild("dragConfirmation", { static: true })
     dragConfirmationModal: NgbModal;
 
@@ -249,7 +252,7 @@ export class BuildingComponent implements OnDestroy {
 
     onDeleteNode(initiative: Initiative) {
       this.modalService
-        .open(this.dragConfirmationModal, { centered: true })
+        .open(this.deleteConfirmationModal, { centered: true })
         .result
         .then(result => {
           if (result) {

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
@@ -59,10 +59,23 @@
 
 			</div>
 			<ng-template #thenDeleteBlock>
-				<button class="btn remove border border-left-0  btn-outline-secondary" placement="top" container="body" mwlConfirmationPopover
-				 [popoverMessage]="'Remove circle and sub-circles ?'" focusbutton="cancel" appendToBody="false" (confirm)="removeChildNode(node.data)"
-				 (cancel)="cancelClicked = true" angularticsEvent="Map" [angularticsProperties]="{mode: 'list', action:'remove', team:teamName, teamId:teamId }"
-				 angulartics2On="click"></button>
+				<button
+          (click)="onDeleteNode(node.data)"
+          class="btn remove border border-left-0  btn-outline-secondary"
+
+          placement="top"
+          container="body"
+          mwlConfirmationPopover
+				  [popoverMessage]="'Remove circle and sub-circles ?'"
+          focusbutton="cancel"
+          appendToBody="false"
+          (confirm)="removeChildNode(node.data)"
+				  (cancel)="cancelClicked = true"
+
+          angularticsEvent="Map"
+          [angularticsProperties]="{mode: 'list', action:'remove', team:teamName, teamId:teamId }"
+				  angulartics2On="click"
+        ></button>
 
 			</ng-template>
 			<ng-template #elseDeleteBlock>
@@ -87,7 +100,7 @@
 			<ng-container *ngTemplateOutlet="nodeEditing"></ng-container>
 
 		</div>
-		
+
 	</ng-template>
 	<ng-template #elseMoveBlock>
 		<div class="input-group rounded" >
@@ -99,7 +112,7 @@
 			<ng-container *ngTemplateOutlet="nodeEditing"></ng-container>
 
 		</div>
-		
+
 
 	</ng-template>
 

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.html
@@ -62,16 +62,6 @@
 				<button
           (click)="onDeleteNode(node.data)"
           class="btn remove border border-left-0  btn-outline-secondary"
-
-          placement="top"
-          container="body"
-          mwlConfirmationPopover
-				  [popoverMessage]="'Remove circle and sub-circles ?'"
-          focusbutton="cancel"
-          appendToBody="false"
-          (confirm)="removeChildNode(node.data)"
-				  (cancel)="cancelClicked = true"
-
           angularticsEvent="Map"
           [angularticsProperties]="{mode: 'list', action:'remove', team:teamName, teamId:teamId }"
 				  angulartics2On="click"

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
@@ -30,6 +30,7 @@ export class InitiativeNodeComponent {
     @Output("update") updateTreeEvent = new EventEmitter<TreeModel>();
     @Output("open") open = new EventEmitter<Initiative>();
     @Output("add") add = new EventEmitter<Initiative>();
+    @Output() delete = new EventEmitter<Initiative>();
 
     @ViewChild("initiative") editInitiative: InitiativeComponent;
 
@@ -112,6 +113,9 @@ export class InitiativeNodeComponent {
         this.add.emit(newNode);
     }
 
+    onDeleteNode(initiative: Initiative) {
+      this.delete.emit(initiative);
+    }
 
     removeChildNode(initiative: Initiative) {
         this.node.treeModel.getNodeById(initiative.id).data.children = [];

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/node/initiative.node.component.ts
@@ -117,18 +117,7 @@ export class InitiativeNodeComponent {
       this.delete.emit(initiative);
     }
 
-    removeChildNode(initiative: Initiative) {
-        this.node.treeModel.getNodeById(initiative.id).data.children = [];
-        let parent = this.node.treeModel.getNodeById(initiative.id).parent;
-        let index = parent.data.children.indexOf(initiative);
-        parent.data.children.splice(index, 1);
-        this.updateTreeEvent.emit(this.node.treeModel);
-        this.edited.emit(true)
-    }
-
     openNode(node: Initiative) {
         this.open.emit(node);
     }
-
-
 }


### PR DESCRIPTION
### Description
Describe what the problem was, what changes have been made to address it, why you've taken a particular approach
From [self-service onboarding spreadsheet](https://docs.google.com/spreadsheets/d/1b5sR4QRbDaIPtE4rLGatkQM48WXHvoG_uyArHA_3Ikg/edit#gid=0&range=E18):
> Add additional warnings to make it much less likely someone will delete circles by accident and make clear there's no undo

Decided to go about this by using the pattern we've got for moving circles - a confirmation dialogue - and adding an additional warning into the alert:
![Screenshot 2022-06-01 at 09 06 46](https://user-images.githubusercontent.com/4092165/171389230-cf8807b5-d9a0-48cc-b1cc-2d45926dbec3.png)

If we need to, we can then also easily add a "type in the name of the circle" to confirm option here. Though likely better to invest time in getting that undo functionality!
