### PR TITLE
Fix deduplication false positives due to undefined emails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  // TODO: Reenable once we're in a good enough place to use strict mode
+	"angular.enable-strict-mode-prompt": false,
+
   // Dictionary with additional words for Code Spell Checker extension
   // https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker
 	"cSpell.words": [

--- a/apps/maptio/src/app/modules/team/pages/team-import/import.component.ts
+++ b/apps/maptio/src/app/modules/team/pages/team-import/import.component.ts
@@ -47,6 +47,11 @@ export class TeamImportComponent implements OnInit {
   ngOnInit() {
     this.route.parent.data.subscribe(
       (data: { assets: { team: Team; datasets: DataSet[] } }) => {
+        // This version of the team object doesn't contain members email
+        // addresses, which then caused deduplication errors, ouch!
+        // We should address this - either with the state management overhaul
+        // or just reading the team information in a different way.
+        // Related issue: https://github.com/Maptio/maptio/issues/739
         this.team = data.assets.team;
       }
     );

--- a/apps/maptio/src/app/shared/services/user/user.service.ts
+++ b/apps/maptio/src/app/shared/services/user/user.service.ts
@@ -587,7 +587,8 @@ export class UserService implements OnDestroy {
     duplicateUsers = duplicateUsers.concat(
       teamMembers.filter(
         (member) => {
-          const doEmailsMatch = member.email === email;
+          const areBothEmailsDefined = !!member.email && !!email;
+          const doEmailsMatch =  areBothEmailsDefined && member.email === email;
           const doNamesMatch = this.areStringsAlmostIdentical(member.name, name)
 
           return doEmailsMatch || doNamesMatch;


### PR DESCRIPTION
### Issue
Fixes #737 

### Description
The problem in #737 was that two `undefined` objects are equal and so if two emails are `undefined` then they were considered to "match" by the silly code I wrote! So, in this PR we prevent that case.

Though note an unaddressed bug in the area described here: #739 