### PR TITLE
Lock map to prevent dataset overrides

### DIFF
--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
@@ -155,19 +155,21 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   // }
 
   async saveChanges(change: { initiative: Initiative; tags: Array<Tag> }) {
-    console.log('Saving dataset');
+    // console.log('Saving dataset');
+
     const isLocalDatasetOutdated = await this.mapService.isDatasetOutdated(
       this.dataset,
       this.user
     );
 
-    console.log('isLocalDatasetOutdated', isLocalDatasetOutdated);
+    // console.log('isLocalDatasetOutdated', isLocalDatasetOutdated);
 
     if (isLocalDatasetOutdated) {
-      console.log('not saving...');
+      // console.log('Not saving because dataset is outdated');
       return;
     }
-    console.log('saving indeed...');
+
+    // console.log('Saving because dataset is not outdated');
 
     this.isEmptyMap =
       !change.initiative.children || change.initiative.children.length === 0;

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
@@ -151,7 +151,24 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   //     this.cd.markForCheck();
   // }
 
-  saveChanges(change: { initiative: Initiative; tags: Array<Tag> }) {
+  async saveChanges(change: { initiative: Initiative; tags: Array<Tag> }) {
+    console.log('Saving dataset;')
+
+    const remoteDataset = await this.datasetFactory.get(this.datasetId);
+
+    console.log('Remote version last edited at', remoteDataset.lastEditedAt);
+    console.log('Remote version last edited by', remoteDataset.lastEditedBy);
+    console.log('Current version last edited at', this.dataset.lastEditedAt);
+    console.log('Current version last edited by', this.dataset.lastEditedBy);
+
+    if (remoteDataset.lastEditedAt !== this.dataset.lastEditedAt) {
+      alert('boom');
+      return;
+    } else {
+      this.dataset.lastEditedAt = new Date().getTime();
+      this.dataset.lastEditedBy = this.user;
+    }
+
     this.isEmptyMap =
       !change.initiative.children || change.initiative.children.length === 0;
     this.isSaving = true;

--- a/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
+++ b/apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts
@@ -25,6 +25,8 @@ import { Role } from '../../../../shared/model/role.data';
 import { Intercom } from 'ng-intercom';
 import { Angulartics2Mixpanel } from 'angulartics2/mixpanel';
 
+import { MapService } from '@maptio-shared/services/map/map.service';
+
 @Component({
   selector: 'maptio-workspace',
   templateUrl: 'workspace.component.html',
@@ -73,6 +75,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     private datasetFactory: DatasetFactory,
     private teamFactory: TeamFactory,
     private dataService: DataService,
+    private mapService: MapService,
     private roleLibrary: RoleLibraryService,
     private cd: ChangeDetectorRef,
     private mixpanel: Angulartics2Mixpanel,
@@ -152,22 +155,19 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   // }
 
   async saveChanges(change: { initiative: Initiative; tags: Array<Tag> }) {
-    console.log('Saving dataset;')
+    console.log('Saving dataset');
+    const isLocalDatasetOutdated = await this.mapService.isDatasetOutdated(
+      this.dataset,
+      this.user
+    );
 
-    const remoteDataset = await this.datasetFactory.get(this.datasetId);
+    console.log('isLocalDatasetOutdated', isLocalDatasetOutdated);
 
-    console.log('Remote version last edited at', remoteDataset.lastEditedAt);
-    console.log('Remote version last edited by', remoteDataset.lastEditedBy);
-    console.log('Current version last edited at', this.dataset.lastEditedAt);
-    console.log('Current version last edited by', this.dataset.lastEditedBy);
-
-    if (remoteDataset.lastEditedAt !== this.dataset.lastEditedAt) {
-      alert('boom');
+    if (isLocalDatasetOutdated) {
+      console.log('not saving...');
       return;
-    } else {
-      this.dataset.lastEditedAt = new Date().getTime();
-      this.dataset.lastEditedBy = this.user;
     }
+    console.log('saving indeed...');
 
     this.isEmptyMap =
       !change.initiative.children || change.initiative.children.length === 0;

--- a/apps/maptio/src/app/shared/model/dataset.data.ts
+++ b/apps/maptio/src/app/shared/model/dataset.data.ts
@@ -1,6 +1,7 @@
 import { Initiative } from './initiative.data';
 import { Serializable } from './../interfaces/serializable.interface';
 import { Tag, DEFAULT_TAGS } from './tag.data';
+import { User } from './user.data';
 import { Role } from './role.data';
 import { Team } from './team.data';
 
@@ -27,6 +28,9 @@ export class DataSet implements Serializable<DataSet> {
   isEmbeddable = false;
   showDescriptions = false;
 
+  lastEditedAt: number;
+  lastEditedBy: User;
+
   public constructor(init?: Partial<DataSet>) {
     Object.assign(this, init);
   }
@@ -49,6 +53,11 @@ export class DataSet implements Serializable<DataSet> {
     deserialized.showDescriptions = input.showDescriptions
       ? input.showDescriptions
       : false;
+
+    deserialized.lastEditedAt = input.lastEditedAt;
+    deserialized.lastEditedBy = input.lastEditedBy
+      ? User.create().deserialize(input.lastEditedBy)
+      : undefined;
 
     let tags = new Array<Tag>();
     if (input.tags && input.tags instanceof Array && input.tags.length > 0) {

--- a/apps/maptio/src/app/shared/services/map/map.service.ts
+++ b/apps/maptio/src/app/shared/services/map/map.service.ts
@@ -29,10 +29,10 @@ export class MapService {
 
     const remoteDataset = await this.datasetFactory.get(datasetId);
 
-    console.log('Remote version last edited at', remoteDataset.lastEditedAt);
-    console.log('Remote version last edited by', remoteDataset.lastEditedBy);
-    console.log('Current version last edited at', localDataset.lastEditedAt);
-    console.log('Current version last edited by', localDataset.lastEditedBy);
+    // console.log('Remote version last edited at', remoteDataset.lastEditedAt);
+    // console.log('Remote version last edited by', remoteDataset.lastEditedBy);
+    // console.log('Current version last edited at', localDataset.lastEditedAt);
+    // console.log('Current version last edited by', localDataset.lastEditedBy);
 
     if (remoteDataset.lastEditedAt !== localDataset.lastEditedAt) {
       alert(

--- a/apps/maptio/src/app/shared/services/map/map.service.ts
+++ b/apps/maptio/src/app/shared/services/map/map.service.ts
@@ -36,7 +36,7 @@ export class MapService {
 
     if (remoteDataset.lastEditedAt !== localDataset.lastEditedAt) {
       alert(
-        'This dataset has been updated by another user. Please copy your latest change, reload the page, and apply your change again. Apologies for the inconvenience. We are working on a new realtime multi-user version of the application.'
+        'Your changes cannot be saved because your local version of the map is outdated. Please copy your latest change, reload the page, and apply your change again. Apologies for the inconvenience. We are working on a new realtime multi-user version of the application.'
       );
       return true;
     } else {


### PR DESCRIPTION
### Issue
Fixes #510 

### Description
This is a workaround for the longstanding bug that can cause data loss when multiple users edit a map. We have a longterm fix planned for this: #238 but that would ideally involve a significant change to the architecture. Instead, we've been discussing options for a workaround for a very long time: #510 and this is, finally, an implementation of a workaround that will hopefully not be too disruptive, won't cause too many bugs. It's still not a mature solution, but it should help. This PR should probably address 90-95% of data loss scenarios - in the simplest possible way. We'll decide whether to cover more scenarios and otherwise improve on this later.

### Setup
Describe how to prepare for testing

### Testing
Open two maps in separate tabs. Edit the map in tab 1. Let the changes save. Edit the map in tab 2. You should now see an alert pop up. If you refresh the page, you should see that your changes haven't been saved.