### PR TITLE
Add map lock to remaining locations

### DIFF
--- a/apps/maptio/src/app/core/http/user/user.factory.ts
+++ b/apps/maptio/src/app/core/http/user/user.factory.ts
@@ -32,7 +32,7 @@ export class UserFactory {
     }
 
     return this.http
-      .get(`/api/v1/user/all/${email}`)
+      .get(`/api/v1/user/all/email/${email}`)
       .pipe(map(this.createUsersFromResponseData))
       .toPromise();
   }

--- a/apps/maptio/src/app/shared/components/cards/map/map-card.component.ts
+++ b/apps/maptio/src/app/shared/components/cards/map/map-card.component.ts
@@ -177,7 +177,7 @@ export class MapCardComponent implements OnInit, OnChanges {
 
   private alertAboutOutdatedDataset() {
     alert(
-      'A friendly heads-up: Your map has been changed by another user (or by you in a different browser tab). Please hit refresh to load the latest version before changing map sharing settings. Sorry for the hassle.'
+      'A friendly heads-up: Your map has been changed by another user (or by you in a different browser tab). Please hit refresh to load the latest version before archiving or restoring your map. Sorry for the hassle.'
     );
   }
 }

--- a/apps/maptio/src/app/shared/components/cards/map/map-card.component.ts
+++ b/apps/maptio/src/app/shared/components/cards/map/map-card.component.ts
@@ -141,7 +141,6 @@ export class MapCardComponent implements OnInit, OnChanges {
     this.cd.markForCheck();
     this.dataset.isArchived = true;
 
-    // TODO: Add map lock
     return this.datasetFactory
       .upsert(this.dataset)
       .then((result) => {
@@ -165,7 +164,6 @@ export class MapCardComponent implements OnInit, OnChanges {
     this.cd.markForCheck();
     this.dataset.isArchived = false;
 
-    // TODO: Add map lock
     return this.datasetFactory
       .upsert(this.dataset)
       .then((result) => {

--- a/apps/maptio/src/app/shared/components/cards/map/map-card.component.ts
+++ b/apps/maptio/src/app/shared/components/cards/map/map-card.component.ts
@@ -15,6 +15,7 @@ import { saveAs } from 'file-saver';
 
 import { DatasetFactory } from '@maptio-core/http/map/dataset.factory';
 import { DataSet } from '@maptio-shared/model/dataset.data';
+import { MapService } from '@maptio-shared/services/map/map.service';
 import { ExportService } from '@maptio-shared/services/export/export.service';
 import { Permissions } from '@maptio-shared/model/permission.data';
 
@@ -49,9 +50,10 @@ export class MapCardComponent implements OnInit, OnChanges {
   isConfiguringEmbedding = false;
 
   constructor(
-    private exportService: ExportService,
+    private cd: ChangeDetectorRef,
     private datasetFactory: DatasetFactory,
-    private cd: ChangeDetectorRef
+    private mapService: MapService,
+    private exportService: ExportService
   ) {}
 
   ngOnInit(): void {
@@ -127,8 +129,13 @@ export class MapCardComponent implements OnInit, OnChanges {
     }
   }
 
-  archive() {
+  async archive() {
     if (this.isArchiving) return;
+
+    if (await this.mapService.isDatasetOutdated(this.dataset)) {
+      this.alertAboutOutdatedDataset();
+      return;
+    }
 
     this.isArchiving = true;
     this.cd.markForCheck();
@@ -146,8 +153,13 @@ export class MapCardComponent implements OnInit, OnChanges {
       });
   }
 
-  restore() {
+  async restore() {
     if (this.isRestoring) return;
+
+    if (await this.mapService.isDatasetOutdated(this.dataset)) {
+      this.alertAboutOutdatedDataset();
+      return;
+    }
 
     this.isRestoring = true;
     this.cd.markForCheck();
@@ -163,5 +175,11 @@ export class MapCardComponent implements OnInit, OnChanges {
         this.isRestoring = false;
         this.cd.markForCheck();
       });
+  }
+
+  private alertAboutOutdatedDataset() {
+    alert(
+      'A friendly heads-up: Your map has been changed by another user (or by you in a different browser tab). Please hit refresh to load the latest version before changing map sharing settings. Sorry for the hassle.'
+    );
   }
 }

--- a/apps/maptio/src/app/shared/services/map/map.service.ts
+++ b/apps/maptio/src/app/shared/services/map/map.service.ts
@@ -87,14 +87,6 @@ export class MapService {
     this.isMultisaveOutdatedCheckCompleted = false;
   }
 
-  archive(dataset: DataSet) {
-    dataset.isArchived = true;
-    // TODO: Add map lock - or remove, this is never used, right?
-    return this.datasetFactory.upsert(dataset).then((archived) => {
-      if (archived) return dataset;
-    });
-  }
-
   /*
    * Creating template, example, and empty datasets
    */

--- a/apps/maptio/src/app/shared/services/user/user.service.ts
+++ b/apps/maptio/src/app/shared/services/user/user.service.ts
@@ -677,12 +677,12 @@ export class UserService implements OnDestroy {
       return dataset.initiative.team_id === team.team_id;
     });
 
-    const outdatedStatusesForEachTeamDataset = await Promise.all(
+    const outdatedStatusForEachTeamDataset = await Promise.all(
       teamDatasets.map(async (dataset) =>
         this.mapService.isDatasetOutdated(dataset)
       )
     );
-    const isAnyDatasetOutdated = outdatedStatusesForEachTeamDataset.some(
+    const isAnyDatasetOutdated = outdatedStatusForEachTeamDataset.some(
       Boolean
     );
 
@@ -734,7 +734,6 @@ export class UserService implements OnDestroy {
       });
 
       try {
-        // TODO: Add map lock
         await this.datasetFactory.upsert(dataset);
       } catch {
         throw new Error(

--- a/apps/maptio/src/app/shared/services/user/user.service.ts
+++ b/apps/maptio/src/app/shared/services/user/user.service.ts
@@ -35,6 +35,7 @@ import { DataSet } from '@maptio-shared/model/dataset.data';
 import { Initiative } from '@maptio-shared/model/initiative.data';
 import { OpenReplayService } from '@maptio-shared/services/open-replay.service';
 import { TeamService } from '@maptio-shared/services/team/team.service';
+import { MapService } from '@maptio-shared/services/map/map.service';
 import {
   UserRole,
   UserRoleService,
@@ -125,6 +126,7 @@ export class UserService implements OnDestroy {
     private teamFactory: TeamFactory,
     private teamService: TeamService,
     private datasetFactory: DatasetFactory,
+    private mapService: MapService,
     private userRoleService: UserRoleService,
     private loaderService: LoaderService,
     @Inject(DOCUMENT) private doc: Document
@@ -666,12 +668,6 @@ export class UserService implements OnDestroy {
 
     const replacementUser = duplicateUsers[0];
 
-    await this.teamService.replaceMember(
-      team,
-      userToBeReplaced,
-      replacementUser
-    );
-
     // Get datasets for the current team
     const teamDatasets = this.userDatasets.filter((dataset) => {
       if (!dataset.initiative) {
@@ -680,6 +676,28 @@ export class UserService implements OnDestroy {
 
       return dataset.initiative.team_id === team.team_id;
     });
+
+    const outdatedStatusesForEachTeamDataset = await Promise.all(
+      teamDatasets.map(async (dataset) =>
+        this.mapService.isDatasetOutdated(dataset)
+      )
+    );
+    const isAnyDatasetOutdated = outdatedStatusesForEachTeamDataset.some(
+      Boolean
+    );
+
+    if (isAnyDatasetOutdated) {
+      alert(
+        'A friendly heads-up: One or more of your maps has been changed by another user (or by you in a different browser tab). Please hit refresh to load the latest version before adding an existing user. Sorry for the hassle.'
+      );
+      return;
+    }
+
+    await this.teamService.replaceMember(
+      team,
+      userToBeReplaced,
+      replacementUser
+    );
 
     teamDatasets.forEach(async (dataset) => {
       dataset.team = team;


### PR DESCRIPTION
### Issue
Fixes #510 

### Description
This is a follow-up to #756 in which we're just extending the map lock to all places where datasets are updated. 