### PR TITLE
Remove Dutch and Japanese for now

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,8 +38,6 @@
         "locales": {
           "de": "apps/maptio/src/locale/messages.de.xlf",
           "fr": "apps/maptio/src/locale/messages.fr.xlf",
-          "ja": "apps/maptio/src/locale/messages.ja.xlf",
-          "nl": "apps/maptio/src/locale/messages.nl.xlf",
           "pl": "apps/maptio/src/locale/messages.pl.xlf"
         }
       },
@@ -51,7 +49,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "localize": ["en-US", "de", "fr", "ja", "nl", "pl"],
+            "localize": ["en-US", "de", "fr", "pl"],
             "outputPath": "dist/apps/maptio",
             "index": "apps/maptio/src/index.html",
             "main": "apps/maptio/src/main.ts",

--- a/apps/maptio-server/src/main.ts
+++ b/apps/maptio-server/src/main.ts
@@ -21,7 +21,7 @@ const app = express();
 const DIST_DIR = path.join(__dirname, '../maptio/');
 const HTML_FILE_NAME = 'index.html';
 
-const LOCALES = ['en-US', 'de', 'fr', 'ja', 'nl', 'pl'];
+const LOCALES = ['en-US', 'de', 'fr', 'pl'];
 const DEFAULT_LOCALE = 'en-US';
 
 const DEFAULT_PORT = 3000;

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -6,8 +6,6 @@ export const commonEnvironment = {
     { code: 'de', name: 'Deutsch', shortLabel: 'DE' },
     { code: 'en-US', name: 'English (United States)', shortLabel: 'EN' },
     { code: 'fr', name: 'Français', shortLabel: 'FR' },
-    { code: 'ja', name: '日本', shortLabel: '日本' },
-    { code: 'nl', name: 'Nederlands', shortLabel: 'NL' },
     { code: 'pl', name: 'Polski', shortLabel: 'PL' },
   ],
 


### PR DESCRIPTION
This builds on top of #779 by removing languages that aren't ready to be deployed just yet.
