### PR TITLE
Add mobile language picker and a few other bits

### DIFF
--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -283,6 +283,10 @@
         <a class="btn btn-link px-0" routerLink="/pricing" i18n>Pricing</a>
       </li>
 
+      <li class="d-md-none dropdown-divider"></li>
+
+      <maptio-language-picker class="d-md-none"></maptio-language-picker>
+
       <ng-container *ngIf="userService.isAuthenticated$ | async">
         <li class="d-md-none dropdown-divider"></li>
 

--- a/apps/maptio/src/app/core/header/language-picker.component.html
+++ b/apps/maptio/src/app/core/header/language-picker.component.html
@@ -1,5 +1,5 @@
 <a
-  class="nav-link dropdown-toggle"
+  class="nav-link dropdown-toggle d-none d-md-block"
   id="languageListDropdownLink"
   data-toggle="dropdown"
   aria-haspopup="true"
@@ -20,3 +20,9 @@
     {{ locale.name }}
   </a>
 </div>
+
+<li class="nav-item d-md-none" *ngFor="let locale of LOCALES">
+  <a class="btn btn-link px-0" (click)="onLanguageSelection(locale)">
+    {{ locale.name }}
+  </a>
+</li>

--- a/apps/maptio/src/app/modules/embed/pages/embed/embed.page.html
+++ b/apps/maptio/src/app/modules/embed/pages/embed/embed.page.html
@@ -6,17 +6,23 @@
 
 <ng-template #datasetUnavailableBlock>
   <div class="message">
-    <ng-container *ngIf="isLoading; else errorBlock">
+    <ng-container *ngIf="isLoading; else errorBlock" i18n>
       Loading Maptio map
     </ng-container>
   </div>
 </ng-template>
 
-<ng-template #errorBlock>
+<ng-template #errorBlock i18n>
   The requested Maptio map could not be found.
 </ng-template>
 
-<a class="credit" href="https://www.maptio.com" (pinch)="onCreditPinch($event)">
+<a
+  class="credit"
+  href="https://www.maptio.com"
+  (pinch)="onCreditPinch($event)"
+  i18n
+>
   <span class="credit__text">Powered by</span>
+  &nbsp;
   <span class="credit__link">Maptio</span>
 </a>

--- a/apps/maptio/src/app/shared/services/user/user.service.ts
+++ b/apps/maptio/src/app/shared/services/user/user.service.ts
@@ -154,8 +154,28 @@ export class UserService implements OnDestroy {
 
   login() {
     return this.auth.loginWithRedirect({
-      ui_locales: this.currentLocaleCode,
+      ui_locales: this.getAuth0SupportedLocale(this.currentLocaleCode),
     });
+  }
+
+  /**
+   * Get locale code from among those supported by Auth0
+   *
+   * Auth0 doesn't automatically switch from a regional language variation, so
+   * we have to add custom logic for this. For example, specifying 'en-US' as
+   * the language for the Auth0 interface will be ignored and, if the user has
+   * a different language set in their browser, the Auth0 pages will be shown
+   * in that language despite Maptio requesting they be showin in "en-US."
+   */
+  private getAuth0SupportedLocale(locale: string) {
+    switch (locale) {
+      case 'en-US':
+        return 'en';
+      case 'en-GB':
+        return 'en';
+      default:
+        return locale;
+    }
   }
 
   logout() {

--- a/apps/maptio/src/locale/messages.xlf
+++ b/apps/maptio/src/locale/messages.xlf
@@ -254,7 +254,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">296,297</context>
+          <context context-type="linenumber">300,301</context>
         </context-group>
       </trans-unit>
       <trans-unit id="f093d9574ab746b231504bd2cbb65f04bd7b00db" datatype="html">
@@ -338,6 +338,27 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/login-error/login-error.page.html</context>
           <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="00e0cd04738f7d2fe0208a6405c6c672e8442624" datatype="html">
+        <source>Loading Maptio map</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/embed/pages/embed/embed.page.html</context>
+          <context context-type="linenumber">10,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5a5331045eea5bbc5c8dfd3a7246a4730a25c795" datatype="html">
+        <source>The requested Maptio map could not be found.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/embed/pages/embed/embed.page.html</context>
+          <context context-type="linenumber">16,17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f8137d54126036e798e54ba70a68ed654320b3a5" datatype="html">
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;credit__text&quot;&gt;"/>Powered by<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/>   <x id="START_TAG_SPAN_1" ctype="x-span_1" equiv-text="&lt;span class=&quot;credit__link&quot;&gt;"/>Maptio<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/embed/pages/embed/embed.page.html</context>
+          <context context-type="linenumber">25,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="c3d4de943e9007c1df3c003b1042299a702aeee8" datatype="html">
@@ -3071,21 +3092,21 @@
         <source>We found multiple duplicated users with 'isInAuth0' set to 'true'.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/shared/services/user/user.service.ts</context>
-          <context context-type="linenumber">654</context>
+          <context context-type="linenumber">655</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5471671537361039738" datatype="html">
         <source>A friendly heads-up: One or more of your maps has been changed by another user (or by you in a different browser tab). Please hit refresh to load the latest version before adding an existing user. Sorry for the hassle.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/shared/services/user/user.service.ts</context>
-          <context context-type="linenumber">693</context>
+          <context context-type="linenumber">694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="363409179927922422" datatype="html">
         <source>Failed to update dataset while replacing duplicate users.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/shared/services/user/user.service.ts</context>
-          <context context-type="linenumber">742</context>
+          <context context-type="linenumber">743</context>
         </context-group>
       </trans-unit>
     </body>

--- a/scripts/i18n-email-templates/src/languages/en.json
+++ b/scripts/i18n-email-templates/src/languages/en.json
@@ -12,7 +12,6 @@
   "changePasswordOutro": "If you <b>did not</b> make this request, please check that you can still log in to your account, and contact us by replying to this email and we'll help.",
 
   "inviteEmailSubject": "{{ nameOfInvitationSender }} invited you to join organization \"{{ team }}\" on Maptio",
-  "inviteEmailMainHeading": "Let's map!",
   "inviteEmailExplanation": "You've been invited to join <strong>{{ team }}</strong> in Maptio - the online tool for visualizing organizations.",
   "inviteEmailCTAIntro": "Your Maptio account is ready for you, all you need to do is set a password by clicking the link below.",
   "inviteEmailCTA": "Log in to Maptio",


### PR DESCRIPTION
### Issue
Fixes #769 

### Description
We've only had a desktop language picker on day 1 of the i18n release, this adds a mobile version too, reusing the current language picker component to avoid over-engineering this.

Also ships a few small things:
* i18n on the embed page and correct spacing for the "Powered by Maptio" message at the bottom 
* Removing an unused string
* Correcting for Auth0 not supporting the "en-US" language code