### PR TITLE
Amend pricing page to match new pricing experiment

### DIFF
--- a/apps/maptio/src/app/core/footer/footer.component.html
+++ b/apps/maptio/src/app/core/footer/footer.component.html
@@ -22,7 +22,7 @@
       </a>
       |
       <a class="small mr-1" routerLink="/pricing">
-        <span i18n>Pricing</span>
+        <span i18n="@@pricing">Pricing</span>
       </a>
     </div>
   </span>

--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -64,13 +64,8 @@
         class="nav-item d-none d-md-flex align-items-center"
         *ngIf="team?.isPaying === false"
       >
-        <a
-          class="nav-link"
-          target="blank"
-          routerLink="/pricing"
-          i18n="@@pricing"
-        >
-          Pricing
+        <a class="nav-link" target="blank" routerLink="/pricing">
+          <ng-container i18n="@@pricing">Pricing</ng-container>
         </a>
       </li>
 
@@ -296,8 +291,8 @@
         </a>
       </li>
       <li class="nav-item d-md-none">
-        <a class="btn btn-link px-0" routerLink="/pricing" i18n="@@pricing">
-          Pricing
+        <a class="btn btn-link px-0" routerLink="/pricing">
+          <ng-container i18n="@@pricing">Pricing</ng-container>
         </a>
       </li>
 

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
@@ -4,8 +4,10 @@
     isAuthenticated: userService.isAuthenticated$ | async
   } as observables"
 >
-  <div class="card-body border-0 bg-white text-center">
-    <div class="card-title border-bottom h4 py-4">
+  <div
+    class="card-body d-flex flex-column align-items-center border-0 bg-white text-center"
+  >
+    <div class="card-title border-bottom h4 py-4 w-100">
       {{ name }}
     </div>
 
@@ -29,7 +31,20 @@
       </a>
     </ng-template>
 
-    <div class="card-text text-muted">{{ text }}</div>
+    <div class="card-text text-muted my-2">
+      <b i18n="@@intendedFor">Intended for:</b>
+
+      <br />
+      <ng-content></ng-content>
+      <br />
+      <br />
+
+      <ng-container i18n="@@14dayFreeTrialDiscountsAvailable">
+        14 Day free trial
+        <br />
+        Discounts available
+      </ng-container>
+    </div>
 
     <div class="card-text">
       <button

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html
@@ -6,14 +6,18 @@
 >
   <div
     class="card-body d-flex flex-column align-items-center border-0 bg-white text-center"
+    style="min-width: 14rem"
   >
     <div class="card-title border-bottom h4 py-4 w-100">
       {{ name }}
     </div>
 
-    <div *ngIf="price; else contactUsPrice" class="card-text d-flex flex-row">
+    <div
+      *ngIf="price; else contactUsPrice"
+      class="card-text d-flex flex-column my-2"
+    >
       <span class="display-4">${{ price }}</span>
-      <small class="ml-2 text-left align-middle align-self-center" i18n>
+      <small class="align-middle align-self-center" i18n>
         per month,
         <br />
         per organization
@@ -31,7 +35,7 @@
       </a>
     </ng-template>
 
-    <div class="card-text text-muted my-2">
+    <div class="card-text text-muted my-3">
       <b i18n="@@intendedFor">Intended for:</b>
 
       <br />

--- a/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.ts
@@ -10,7 +10,7 @@ import { BillingSchedule } from './billing-schedule.enum';
 })
 export class PaymentPlanComponent implements OnChanges {
   @HostBinding('class') classes =
-    'col-12 col-md-3 accent-blue rounded-bottom box-shadow mx-2 my-3';
+    'col-12 col-md-4 accent-blue rounded-bottom box-shadow mx-2 my-3';
 
   @Input() name: string;
   @Input() text: number;

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -53,26 +53,9 @@
       class="d-flex flex-column flex-md-row justify-content-center align-items-stretch"
     >
       <maptio-payment-plan
-        name="Starter"
-        text="1 - 12 people"
+        name="Strivers"
         i18n-name
-        i18n-text
-        [billingSchedule]="billingScheduleChoice"
-        [prices]="{
-          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_COST,
-          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_COST
-        }"
-        [billingLinks]="{
-          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_URL,
-          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_URL
-        }"
-      ></maptio-payment-plan>
-
-      <maptio-payment-plan
-        name="Small"
-        text="13 - 35 people"
-        i18n-name
-        i18n-text
+        i18n="@@striversPlanDescription"
         [billingSchedule]="billingScheduleChoice"
         [prices]="{
           MONTHLY: BILLING_PLANS.SMALL_MONTHLY_COST,
@@ -82,13 +65,18 @@
           MONTHLY: BILLING_PLANS.SMALL_MONTHLY_URL,
           ANNUAL: BILLING_PLANS.SMALL_ANNUAL_URL
         }"
-      ></maptio-payment-plan>
+      >
+        individuals,
+        <br />
+        tiny teams,
+        <br />
+        and the cash-poor
+      </maptio-payment-plan>
 
       <maptio-payment-plan
-        name="Standard plan"
-        text="36 - 200 people"
+        name="Pioneers"
         i18n-name
-        i18n-text
+        i18n="@@pioneersPlanDescription"
         [billingSchedule]="billingScheduleChoice"
         [prices]="{
           MONTHLY: BILLING_PLANS.STANDARD_MONTHLY_COST,
@@ -98,7 +86,33 @@
           MONTHLY: BILLING_PLANS.STANDARD_MONTHLY_URL,
           ANNUAL: BILLING_PLANS.STANDARD_ANNUAL_URL
         }"
-      ></maptio-payment-plan>
+      >
+        small teams of 10-35 people
+        <br />
+        and non-profits
+        <br />
+      </maptio-payment-plan>
+
+      <maptio-payment-plan
+        name="Heroes"
+        i18n-name
+        i18n="@@heroesPlanDescription"
+        [billingSchedule]="billingScheduleChoice"
+        [prices]="{
+          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_COST,
+          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_COST
+        }"
+        [billingLinks]="{
+          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_URL,
+          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_URL
+        }"
+      >
+        35 - 250 people in
+        <br />
+        commercial initiatives and
+        <br />
+        well-funded non-profits
+      </maptio-payment-plan>
     </div>
 
     <br />

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -58,12 +58,10 @@
         i18n="@@striversPlanDescription"
         [billingSchedule]="billingScheduleChoice"
         [prices]="{
-          MONTHLY: BILLING_PLANS.SMALL_MONTHLY_COST,
-          ANNUAL: BILLING_PLANS.SMALL_ANNUAL_COST
+          MONTHLY: BILLING_PLANS.STRIVERS_MONTHLY_COST
         }"
         [billingLinks]="{
-          MONTHLY: BILLING_PLANS.SMALL_MONTHLY_URL,
-          ANNUAL: BILLING_PLANS.SMALL_ANNUAL_URL
+          MONTHLY: BILLING_PLANS.STRIVERS_MONTHLY_URL
         }"
       >
         individuals,
@@ -79,12 +77,10 @@
         i18n="@@pioneersPlanDescription"
         [billingSchedule]="billingScheduleChoice"
         [prices]="{
-          MONTHLY: BILLING_PLANS.STANDARD_MONTHLY_COST,
-          ANNUAL: BILLING_PLANS.STANDARD_ANNUAL_COST
+          MONTHLY: BILLING_PLANS.PIONEERS_MONTHLY_COST
         }"
         [billingLinks]="{
-          MONTHLY: BILLING_PLANS.STANDARD_MONTHLY_URL,
-          ANNUAL: BILLING_PLANS.STANDARD_ANNUAL_URL
+          MONTHLY: BILLING_PLANS.PIONEERS_MONTHLY_URL
         }"
       >
         small teams of 10-35 people
@@ -99,12 +95,10 @@
         i18n="@@heroesPlanDescription"
         [billingSchedule]="billingScheduleChoice"
         [prices]="{
-          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_COST,
-          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_COST
+          MONTHLY: BILLING_PLANS.HEROES_MONTHLY_COST
         }"
         [billingLinks]="{
-          MONTHLY: BILLING_PLANS.STARTER_MONTHLY_URL,
-          ANNUAL: BILLING_PLANS.STARTER_ANNUAL_URL
+          MONTHLY: BILLING_PLANS.HEROES_MONTHLY_URL
         }"
       >
         35 - 250 people in

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -146,7 +146,7 @@
         class="btn-block w-100 btn btn-success btn-md-lg my-4"
         i18n="@@tryMaptioForFree"
       >
-        Try Maptio for free
+        Try Maptio for FREE
       </button>
     </div>
 

--- a/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
+++ b/apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html
@@ -2,67 +2,52 @@
   <div
     class="d-flex flex-column justify-content-center align-items-center col-12"
   >
-    <h1
-      class="w-100 d-none d-md-block text-left text-md-center mb-md-0"
-      i18n="@@chooseYourPlan"
-    >
-      Choose your plan
-    </h1>
-    <h3
-      class="w-100 d-block d-md-none text-left text-md-center mb-md-0"
-      i18n="@@chooseYourPlan"
-    >
-      Choose your plan
-    </h3>
+    <br />
 
-    <div class="col-12 px-0 col-md-auto">
-      <button
-        maptioLoginRedirect
-        [isSignup]="true"
-        *ngIf="(userService.isAuthenticated$ | async) === false"
-        class="btn-block w-100 btn btn-success btn-md-lg my-4"
-        i18n
-      >
-        Get started - try Maptio for free
-      </button>
-    </div>
+    <h1 i18n="@@pricing" class="text-bold">Pricing</h1>
 
+    <br />
+
+    <p class="h2 text-center" i18n="@@customersHaveDifferentAbilitiesToPay">
+      Customers have very different abilities to pay,
+      <br class="d-none d-md-block" />
+      so we have an honor-based pricing model.
+    </p>
+
+    <br />
+    <br />
+
+    <p i18n="@@ourCauseIsToServe">
+      Our cause is to serve as many other cause-driven initiatives as possible.
+    </p>
+
+    <p i18n="@@weTrustYouToPay">
+      We trust you to pay the right amount for you.
+    </p>
+
+    <p i18n="@@pleaseHelpFundUs">
+      Please help fund us to improve Maptio for everyone.
+    </p>
+
+    <br />
+    <br />
+
+    <p class="h3 text-center" i18n="@@youCanChooseYourOwnPrice">
+      You can choose your own price level.
+      <br class="d-none d-md-block" />
+      All levels have full access to Maptio.
+    </p>
+
+    <br />
+    <br />
+
+    <!--
     <p class="text-center text-muted my-5" i18n>
       Pricing in US Dollars. All major credit cards accepted.
       <br />
       No minimum contract length.
     </p>
-
-    <div
-      ngbRadioGroup
-      [(ngModel)]="billingScheduleChoice"
-      class="btn-group btn-group-toggle mb-3"
-      name="radioBasic"
-    >
-      <label
-        ngbButtonLabel
-        class="btn-lg"
-        [class]="
-          billingScheduleChoice === BillingSchedule.ANNUAL ?
-          'btn-success' : 'btn-light'
-        "
-      >
-        <input ngbButton type="radio" [value]="BillingSchedule.ANNUAL" />
-        <ng-container i18n>Annual billing</ng-container>
-      </label>
-
-      <label
-        ngbButtonLabel
-        class="btn-lg"
-        [class]="
-          billingScheduleChoice === BillingSchedule.MONTHLY ?
-          'btn-success' : 'btn-light'
-        "
-      >
-        <input ngbButton type="radio" [value]="BillingSchedule.MONTHLY" />
-        <ng-container i18n>Monthly billing</ng-container>
-      </label>
-    </div>
+    -->
 
     <div
       class="d-flex flex-column flex-md-row justify-content-center align-items-stretch"
@@ -114,22 +99,50 @@
           ANNUAL: BILLING_PLANS.STANDARD_ANNUAL_URL
         }"
       ></maptio-payment-plan>
-
-      <maptio-payment-plan
-        name="Larger organizations"
-        text="200+ people"
-        i18n-name
-        i18n-text
-      ></maptio-payment-plan>
     </div>
 
-    <p class="text-center text-muted my-5" i18n>
-      Struggling to afford this? Let's talk and work something out.
-      <a href="mailto:support@maptio.com?subject=Deal request">Contact us.</a>
-      <br />
-      <br />
-      Our mission is to serve the most cause-driven organizations on the planet.
-      Discounts available for non-profits.
+    <br />
+    <br />
+
+    <h2 i18n="@@discounts">Discounts</h2>
+
+    <p i18n="@@asACauseDrivenCompany">
+      As a cause-driven company we don't want money to be a barrier for anyone.
     </p>
+
+    <p i18n="@@youCanChooseYourIdealPrice">
+      You can choose your ideal price point then take a discount you need to
+      afford Maptio.
+    </p>
+
+    <p i18n="@@discountCodes20love40help">
+      20% off: use code
+      <b>love</b>
+      <br />
+      40% off: use code
+      <b>help</b>
+    </p>
+
+    <p i18n="@@pleaseSupportTheDevelopmentOfMaptio">
+      Please support the development of Maptio by only taking off what you
+      really need.
+    </p>
+
+    <p>❤️</p>
+
+    <div class="col-12 px-0 col-md-auto">
+      <button
+        maptioLoginRedirect
+        [isSignup]="true"
+        *ngIf="(userService.isAuthenticated$ | async) === false"
+        class="btn-block w-100 btn btn-success btn-md-lg my-4"
+        i18n="@@tryMaptioForFree"
+      >
+        Try Maptio for free
+      </button>
+    </div>
+
+    <br />
+    <br />
   </div>
 </div>

--- a/apps/maptio/src/environments/environment.common.ts
+++ b/apps/maptio/src/environments/environment.common.ts
@@ -22,26 +22,17 @@ export const commonEnvironment = {
   SUBSCRIBE_NOW_LINK: '/pricing',
 
   BILLING_PLANS: {
-    STARTER_MONTHLY_COST: '20',
-    STARTER_MONTHLY_URL:
-      'https://maptio.chargebee.com/hosted_pages/plans/standard-plan12',
-    STARTER_ANNUAL_COST: '18',
-    STARTER_ANNUAL_URL:
-      'https://maptio.chargebee.com/hosted_pages/plans/annual_12_18',
+    STRIVERS_MONTHLY_COST: '25',
+    STRIVERS_MONTHLY_URL:
+      'https://maptio.chargebee.com/hosted_pages/plans/monthy_strivers',
 
-    SMALL_MONTHLY_COST: '50',
-    SMALL_MONTHLY_URL:
-      'https://maptio.chargebee.com/hosted_pages/plans/standard-plan50',
-    SMALL_ANNUAL_COST: '45',
-    SMALL_ANNUAL_URL:
-      'https://maptio.chargebee.com/hosted_pages/plans/annual_35_50',
+    PIONEERS_MONTHLY_COST: '60',
+    PIONEERS_MONTHLY_URL:
+      'https://maptio.chargebee.com/hosted_pages/plans/monthy_pioneers',
 
-    STANDARD_MONTHLY_COST: '99',
-    STANDARD_MONTHLY_URL:
-      'https://maptio.chargebee.com/hosted_pages/plans/standard-plan',
-    STANDARD_ANNUAL_COST: '89',
-    STANDARD_ANNUAL_URL:
-      'https://maptio.chargebee.com/hosted_pages/plans/annual-standard-plan',
+    HEROES_MONTHLY_COST: '120',
+    HEROES_MONTHLY_URL:
+      'https://maptio.chargebee.com/hosted_pages/plans/monthy_heroes',
   },
 
   ONBOARDING_MESSAGES: {

--- a/apps/maptio/src/locale/messages.de.xlf
+++ b/apps/maptio/src/locale/messages.de.xlf
@@ -102,18 +102,6 @@
           <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <target state="translated">Preisgestaltung</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
         <source>Copyright</source>
         <target state="translated">Copyright</target>
@@ -2461,18 +2449,6 @@
           <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="chooseYourPlan" datatype="html">
-        <source>Choose your plan</source>
-        <target state="translated">Wähle dein Abonnement aus</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">9,10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">15,16</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="contactUs" datatype="html">
         <source>Contact us</source>
         <target state="translated">Kontakt</target>
@@ -2485,14 +2461,6 @@
           <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="beb13b8cf46197116e7cfc1d65c7c20b9dc9b43a" datatype="html">
-        <source>Annual billing</source>
-        <target state="translated">Jährliche Abrechnung</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
         <source>1 - 12 people</source>
         <target state="translated">1 - 12 Personen</target>
@@ -2501,28 +2469,12 @@
           <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
-        <source>13 - 35 people</source>
-        <target state="translated">13 - 35 Personen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6695dcc9f3e85f97fc1b47b4e353875a20f7c543" datatype="html">
         <source>200+ people</source>
         <target state="translated">200+ Personen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">120</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
-        <source>36 - 200 people</source>
-        <target state="translated">36 - 200 Personen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1d13cd52e7cd00d13b2e10f9f6d48dc032738f38" datatype="html">
@@ -2563,14 +2515,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/http/map/dataset.factory.ts</context>
           <context context-type="linenumber">50</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
-        <source>Standard plan</source>
-        <target state="translated">Standard-Abo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="39665ca29f333f6c22cd0e5c4c32b9de84d25f72" datatype="html">
@@ -2713,14 +2657,6 @@
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="fae28db5960f6ec8a618b29d7c245fed8d8e0f05" datatype="html">
-        <source>Get started - try Maptio for free</source>
-        <target state="translated">Starte durch und probiere Maptio kostenlos aus</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="0948acbf2eb00c73d4eb4d6b2066a8044dd018b8" datatype="html">
         <source>Pricing in US Dollars. All major credit cards accepted. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> No minimum contract length.</source>
         <target state="translated">Preise in US Dollar. Alle gängigen Kreditkarten werden akzeptiert. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Keine Mindestvertragslaufzeit.</target>
@@ -2729,28 +2665,12 @@
           <context context-type="linenumber">31,34</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c5376ad5fd8f2dece083dd9b46151312173e76c1" datatype="html">
-        <source>Monthly billing</source>
-        <target state="translated">Monatliche Abrechnung</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
         <source>Starter</source>
         <target state="translated">Starter</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
-        <source>Small</source>
-        <target state="translated">Klein-Betrieb</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
@@ -2991,14 +2911,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
           <context context-type="linenumber">155</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">
-        <source>Struggling to afford this? Let's talk and work something out. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Contact us.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Our mission is to serve the most cause-driven organizations on the planet. Discounts available for non-profits.</source>
-        <target state="translated">Ist das nicht leistbar? Lass uns reden und eine Lösung finden. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Kontaktieren Sie uns.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Wir haben es uns zur Aufgabe gemacht, Organisationen zu unterstützen, die aktiv die Welt von morgen mitgestalten. Für gemeinnützige Organisationen sind Ermäßigungen erhältlich.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">127,133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8104feb61691b7534c05113fb2a13e40c60b82d2" datatype="html">

--- a/apps/maptio/src/locale/messages.es.xlf
+++ b/apps/maptio/src/locale/messages.es.xlf
@@ -91,17 +91,6 @@
           <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
         <source>Copyright</source>
         <context-group purpose="location">

--- a/apps/maptio/src/locale/messages.fr.xlf
+++ b/apps/maptio/src/locale/messages.fr.xlf
@@ -70,28 +70,12 @@
           <context context-type="linenumber">15</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
-        <source>13 - 35 people</source>
-        <target state="translated">13 - 35 personnes</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
         <source>1 - 12 people</source>
         <target state="translated">1 - 12 personnes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">72</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6695dcc9f3e85f97fc1b47b4e353875a20f7c543" datatype="html">
-        <source>200+ people</source>
-        <target state="translated">200+ personnes</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
@@ -368,14 +352,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/onboarding-banner.component.html</context>
           <context context-type="linenumber">34</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="beb13b8cf46197116e7cfc1d65c7c20b9dc9b43a" datatype="html">
-        <source>Annual billing</source>
-        <target state="translated">Facturation annuelle</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="chooseYourPlan" datatype="html">
@@ -1410,28 +1386,12 @@
           <context context-type="linenumber">16</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="fae28db5960f6ec8a618b29d7c245fed8d8e0f05" datatype="html">
-        <source>Get started - try Maptio for free</source>
-        <target state="translated">Commencer en essayant Maptio gratuitement</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="c5376ad5fd8f2dece083dd9b46151312173e76c1" datatype="html">
         <source>Monthly billing</source>
         <target state="translated">Facturation mensuelle</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
-        <source>Larger organizations</source>
-        <target state="translated">Grandes entreprises</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="e6746170f3f39bd0b0a905cb9b232cae9d3a9e50" datatype="html">
@@ -2113,14 +2073,6 @@
         <note priority="1" from="description">Button to exit the onboarding process and start using the app</note>
         <note priority="1" from="meaning">onboarding</note>
       </trans-unit>
-      <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">
-        <source>Struggling to afford this? Let's talk and work something out. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Contact us.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Our mission is to serve the most cause-driven organizations on the planet. Discounts available for non-profits.</source>
-        <target state="translated">Vous avez du mal à vous le permettre ? Parlons-en et trouvons une solution. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Contactez-nous.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Notre mission est de servir les entreprises qui veulent contribuer activement à un meilleur futur. Rabais disponibles pour les organismes à but non lucratif.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">127,133</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="onboarding-consent-error" datatype="html">
         <source>There was an error when updating consent. You can chat with us or email us at <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Error when updating consent&quot;&gt;"/> support@maptio.com <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> if you'd like to report the issue and notify us of your consent preferences.</source>
         <target state="translated">Une erreur s'est produite lors de la mise à jour du consentement. Vous pouvez clavarder avec nous ou nous envoyer un e-mail à <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Error when updating consent&quot;&gt;"/> support@maptio.com <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/> si vous souhaitez signaler le problème et nous informer de vos préférences de consentement.</target>
@@ -2664,18 +2616,6 @@
           <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <target state="translated">Tarification</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="994363f08f9fbfa3b3994ff7b35c6904fdff18d8" datatype="html">
         <source>Profile</source>
         <target state="translated">Profil</target>
@@ -2744,28 +2684,12 @@
           <context context-type="linenumber">365,369</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0948acbf2eb00c73d4eb4d6b2066a8044dd018b8" datatype="html">
-        <source>Pricing in US Dollars. All major credit cards accepted. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> No minimum contract length.</source>
-        <target state="translated">Prix en dollars américains. Toutes les principales cartes de crédit sont acceptées. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Pas de durée minimale de contrat.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">31,34</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
         <source>Small</source>
         <target state="translated">Petite entreprise</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">87</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
-        <source>Standard plan</source>
-        <target state="translated">Moyenne entreprise</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">

--- a/apps/maptio/src/locale/messages.ja.xlf
+++ b/apps/maptio/src/locale/messages.ja.xlf
@@ -102,18 +102,6 @@
           <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <target state="translated">料金</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
         <source>Copyright</source>
         <target state="translated">著作権</target>
@@ -2450,18 +2438,6 @@
           <context context-type="linenumber">81,82</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="chooseYourPlan" datatype="html">
-        <source>Choose your plan</source>
-        <target state="translated">プランの選択</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">9,10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">15,16</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="contactUs" datatype="html">
         <source>Contact us</source>
         <target state="translated">お問い合わせ</target>
@@ -2488,14 +2464,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
           <context context-type="linenumber">49</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="beb13b8cf46197116e7cfc1d65c7c20b9dc9b43a" datatype="html">
-        <source>Annual billing</source>
-        <target state="translated">年間契約</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="selectAll" datatype="html">
@@ -2694,14 +2662,6 @@
           <context context-type="linenumber">155</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c5376ad5fd8f2dece083dd9b46151312173e76c1" datatype="html">
-        <source>Monthly billing</source>
-        <target state="translated">月額課金</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
         <source>Small</source>
         <target state="translated">スモールチーム</target>
@@ -2710,28 +2670,12 @@
           <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
-        <source>Standard plan</source>
-        <target state="translated">スタンダード</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">103</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
         <source>Larger organizations</source>
         <target state="translated">大規模な組織</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">119</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6695dcc9f3e85f97fc1b47b4e353875a20f7c543" datatype="html">
-        <source>200+ people</source>
-        <target state="translated">201名以上</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="map" datatype="html">
@@ -2866,28 +2810,12 @@
           <context context-type="linenumber">102</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
-        <source>36 - 200 people</source>
-        <target state="translated">36～200名</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">104</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
         <source>13 - 35 people</source>
         <target state="translated">13～35名</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
-        <source>1 - 12 people</source>
-        <target state="translated">1～12名</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5471671537361039738" datatype="html">
@@ -2912,14 +2840,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.ts</context>
           <context context-type="linenumber">166</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
-        <source>Starter</source>
-        <target state="translated">スターター</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8104feb61691b7534c05113fb2a13e40c60b82d2" datatype="html">
@@ -2974,14 +2894,6 @@
           <context context-type="linenumber">185,188</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="fae28db5960f6ec8a618b29d7c245fed8d8e0f05" datatype="html">
-        <source>Get started - try Maptio for free</source>
-        <target state="translated">利用開始 - Maptioを無料でお試しください。</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="2619407874098925475" datatype="html">
         <source>Sub-circles are just circles that appear within another circle. You can have sub-circles many levels deep.</source>
         <target state="translated">サブサークルは、他のサークルの中に現れるサークルです。サブサークルは複数の階層で作ることができます</target>
@@ -3032,14 +2944,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/http/map/dataset.factory.ts</context>
           <context context-type="linenumber">50</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="0948acbf2eb00c73d4eb4d6b2066a8044dd018b8" datatype="html">
-        <source>Pricing in US Dollars. All major credit cards accepted. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> No minimum contract length.</source>
-        <target state="translated">価格はUSドルで表示されます。主要なクレジットカードが利用可能です。 <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 最低契約期間はありません</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">31,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">

--- a/apps/maptio/src/locale/messages.nl.xlf
+++ b/apps/maptio/src/locale/messages.nl.xlf
@@ -141,18 +141,6 @@
           <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <target state="translated">Prijzen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
         <source>Copyright</source>
         <target state="translated">Copyright</target>
@@ -907,31 +895,12 @@
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="chooseYourPlan" datatype="html">
-        <source>Choose your plan</source>
-        <target state="translated">Kies je abonnement</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">9,10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">15,16</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="fae28db5960f6ec8a618b29d7c245fed8d8e0f05" datatype="html">
         <source>Get started - try Maptio for free</source>
         <target state="translated">Probeer Maptio gratis uit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">26,27</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="0948acbf2eb00c73d4eb4d6b2066a8044dd018b8" datatype="html">
-        <source>Pricing in US Dollars. All major credit cards accepted. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> No minimum contract length.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">31,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="beb13b8cf46197116e7cfc1d65c7c20b9dc9b43a" datatype="html">
@@ -942,26 +911,11 @@
           <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c5376ad5fd8f2dece083dd9b46151312173e76c1" datatype="html">
-        <source>Monthly billing</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
         <source>Starter</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
-        <source>1 - 12 people</source>
-        <target state="translated">1 - 12 mensen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
@@ -971,14 +925,6 @@
           <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
-        <source>13 - 35 people</source>
-        <target state="translated">13 - 35 mensen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
         <source>Standard plan</source>
         <context-group purpose="location">
@@ -986,27 +932,11 @@
           <context context-type="linenumber">103</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
-        <source>36 - 200 people</source>
-        <target state="translated">36 - 200 mensen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">104</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
         <source>Larger organizations</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">119</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6695dcc9f3e85f97fc1b47b4e353875a20f7c543" datatype="html">
-        <source>200+ people</source>
-        <target state="translated">200+ mensen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">120</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">

--- a/apps/maptio/src/locale/messages.pl.xlf
+++ b/apps/maptio/src/locale/messages.pl.xlf
@@ -93,18 +93,6 @@
           <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <target>Cennik</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
         <source>Copyright</source>
         <target>Wszelkie prawa zastrzeżone</target>
@@ -2623,18 +2611,6 @@
           <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="chooseYourPlan" datatype="html">
-        <source>Choose your plan</source>
-        <target state="translated">Wybierz swój plan</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">9,10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">15,16</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="contactUs" datatype="html">
         <source>Contact us</source>
         <target state="translated">Skontaktuj się z nami</target>
@@ -2645,14 +2621,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
           <context context-type="linenumber">57</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="fae28db5960f6ec8a618b29d7c245fed8d8e0f05" datatype="html">
-        <source>Get started - try Maptio for free</source>
-        <target state="translated">Rozpocznij - wypróbuj Maptio za darmo</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">26,27</context>
         </context-group>
       </trans-unit>
       <trans-unit id="62ad8dbe2ef4b33254bc85995cfefe0922be9838" datatype="html">
@@ -2679,30 +2647,6 @@
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
-        <source>1 - 12 people</source>
-        <target state="translated">1 - 12 osób</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">72</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="beb13b8cf46197116e7cfc1d65c7c20b9dc9b43a" datatype="html">
-        <source>Annual billing</source>
-        <target state="translated">Rozliczenia roczne</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">51</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
-        <source>Small</source>
-        <target state="translated">Mały</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">87</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
         <source>Starter</source>
         <target state="translated">Starter</target>
@@ -2711,60 +2655,12 @@
           <context context-type="linenumber">71</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
-        <source>13 - 35 people</source>
-        <target state="translated">13 - 35 osób</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">88</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="6695dcc9f3e85f97fc1b47b4e353875a20f7c543" datatype="html">
-        <source>200+ people</source>
-        <target state="translated">Ponad 200 osób</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">120</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
-        <source>36 - 200 people</source>
-        <target state="translated">36 - 200 osób</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">104</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
         <source>Larger organizations</source>
         <target state="translated">Większe organizacje</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">119</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
-        <source>Standard plan</source>
-        <target state="translated">Plan standardowy</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">103</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="c5376ad5fd8f2dece083dd9b46151312173e76c1" datatype="html">
-        <source>Monthly billing</source>
-        <target state="translated">Rozliczenia miesięczne</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">63</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="0948acbf2eb00c73d4eb4d6b2066a8044dd018b8" datatype="html">
-        <source>Pricing in US Dollars. All major credit cards accepted. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> No minimum contract length.</source>
-        <target state="translated">Ceny w dolarach amerykańskich. Wszystkie główne karty kredytowe akceptowane. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Brak minimalnej długości umowy.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">31,34</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">
@@ -3161,6 +3057,230 @@
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/workspace/pages/workspace/workspace.component.html</context>
           <context context-type="linenumber">7,8</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="00e0cd04738f7d2fe0208a6405c6c672e8442624" datatype="html">
+        <source>Loading Maptio map</source>
+        <target state="translated">Ładowanie mapy Maptio</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/embed/pages/embed/embed.page.html</context>
+          <context context-type="linenumber">10,11</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="5a5331045eea5bbc5c8dfd3a7246a4730a25c795" datatype="html">
+        <source>The requested Maptio map could not be found.</source>
+        <target state="translated">Mapa nie została odnaleziona.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/embed/pages/embed/embed.page.html</context>
+          <context context-type="linenumber">16,17</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4733181597636202178" datatype="html">
+        <source>A person with the same email is already a member of your organization</source>
+        <target state="translated">Osoba o tym samym adresie e-mail jest już członkiem Twojej organizacji</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/team/pages/team-import/import.component.ts</context>
+          <context context-type="linenumber">106</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="498451842164304578" datatype="html">
+        <source>Multiple existing people with this email or name found</source>
+        <target state="translated">Znaleziono wiele istniejących osób z tym adresem e-mail lub imieniem i nazwiskiem</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/team/pages/team-import/import.component.ts</context>
+          <context context-type="linenumber">95</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="4494204084031514457" datatype="html">
+        <source>Added email address to existing person with the same name</source>
+        <target state="translated">Dodano adres e-mail do istniejącej osoby o tym samym imieniu</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/team/pages/team-import/import.component.ts</context>
+          <context context-type="linenumber">114</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="580ee0f119c40b7426c7dfd3f85520321a1c2a5a" datatype="html">
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;credit__text&quot;&gt;"/>Powered by<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/><x id="START_TAG_SPAN_1" ctype="x-span_1" equiv-text="&lt;span class=&quot;credit__link&quot;&gt;"/> Maptio<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></source>
+        <target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;credit__text&quot;&gt;"/>Mapa stworzona w<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/><x id="START_TAG_SPAN_1" ctype="x-span_1" equiv-text="&lt;span class=&quot;credit__link&quot;&gt;"/> Maptio<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/embed/pages/embed/embed.page.html</context>
+          <context context-type="linenumber">25,26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="7254563407602262950" datatype="html">
+        <source>An unexpected duplication-related error occurred</source>
+        <target state="translated">Wystąpił nieoczekiwany błąd związany z duplikacją</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/team/pages/team-import/import.component.ts</context>
+          <context context-type="linenumber">119</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="9063678978754194989" datatype="html">
+        <source>A person with the same name is already a member of your organization</source>
+        <target state="translated">Osoba o tym samym imieniu i nazwisku jest już członkiem Twojej organizacji</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/team/pages/team-import/import.component.ts</context>
+          <context context-type="linenumber">125</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="striversPlanDescription" datatype="html">
+        <source>individuals, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> tiny teams, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> and the cash-poor</source>
+        <target state="translated">osób indywidualnych, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> małych zespołów, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> i ubogich w gotówkę</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">67,72</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="intendedFor" datatype="html">
+        <source>Intended for:</source>
+        <target state="translated">Przeznaczone dla:</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ourCauseIsToServe" datatype="html">
+        <source>Our cause is to serve as many other cause-driven initiatives as possible.</source>
+        <target state="translated">Naszym celem jest służenie jak największej liczbie innych inicjatyw prospołecznych.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">21,22</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="284f7a5a4e600a530964c571e426db23cd76b4fb" datatype="html">
+        <source>Pioneers</source>
+        <target state="needs-translation">Pionierzy</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">75</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="pleaseHelpFundUs" datatype="html">
+        <source>Please help fund us to improve Maptio for everyone.</source>
+        <target state="translated">Pomóż nam ulepszyć Maptio dla wszystkich.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">29,30</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="908d8a67826fc56e92aba7638b795d73b23fbaaf" datatype="html">
+        <source>Strivers</source>
+        <target state="translated">Dążący</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="weTrustYouToPay" datatype="html">
+        <source>We trust you to pay the right amount for you.</source>
+        <target state="translated">Ufamy, że zapłacisz odpowiednią dla Ciebie kwotę.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">25,26</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="youCanChooseYourOwnPrice" datatype="html">
+        <source>You can choose your own price level. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br class=&quot;d-none d-md-block&quot; /&gt;"/> All levels have full access to Maptio.</source>
+        <target state="translated">Możesz wybrać swój własny poziom cenowy. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br class=&quot;d-none d-md-block&quot; /&gt;"/> Wszystkie poziomy mają pełny dostęp do Maptio.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">36,39</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="heroesPlanDescription" datatype="html">
+        <source>35 - 250 people in <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> commercial initiatives and <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> well-funded non-profits</source>
+        <target state="needs-translation">35 - 250 osób w &lt;x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/&gt; inicjatywach komercyjnych i &lt;x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/&gt; dobrze finansowanych organizacjach non-profit</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">104,109</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="discounts" datatype="html">
+        <source>Discounts</source>
+        <target state="translated">Zniżki</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">115</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="33a29e29d6c1ae044e8e3350733a49c8dbeb18af" datatype="html">
+        <source>Heroes</source>
+        <target state="translated">Bohaterowie</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">93</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="pleaseSupportTheDevelopmentOfMaptio" datatype="html">
+        <source>Please support the development of Maptio by only taking off what you really need.</source>
+        <target state="translated">Wspieraj rozwój Maptio, korzystając tylko z takiej zniżki, jakiej naprawdę potrzebujesz.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">135,137</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tryMaptioForFree" datatype="html">
+        <source>Try Maptio for FREE</source>
+        <target state="translated">Wypróbuj Maptio za DARMO</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">149,150</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6453822529269960276" datatype="html">
+        <source>An unexpected duplication error occurred</source>
+        <target state="needs-translation">Wystąpił nieoczekiwany błąd duplikacji</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/team/pages/team-import/import.component.ts</context>
+          <context context-type="linenumber">130</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="14dayFreeTrialDiscountsAvailable" datatype="html">
+        <source>14 Day free trial <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Discounts available</source>
+        <target state="translated">14-dniowy bezpłatny okres próbny <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Dostępne zniżki</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
+          <context context-type="linenumber">47,50</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="discountCodes20love40help" datatype="html">
+        <source>20% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>love<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 40% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>help<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>
+        <target state="needs-translation">20% zniżki: użyj kodu &lt;x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/&gt;love&lt;x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/&gt;&lt;x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/&gt; 40% zniżki: użyj kodu &lt;x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/&gt;help&lt;x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/&gt;</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">127,131</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="pioneersPlanDescription" datatype="html">
+        <source>small teams of 10-35 people <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> and non-profits <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/></source>
+        <target state="translated">małych zespołów liczących od 10 do 35 osób <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> i organizacji non-profit <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">86,89</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="asACauseDrivenCompany" datatype="html">
+        <source>As a cause-driven company we don't want money to be a barrier for anyone.</source>
+        <target state="translated">Jako firma zorientowana na cele prospołeczne nie chcemy, aby pieniądze były dla kogokolwiek barierą.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">118,119</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="customersHaveDifferentAbilitiesToPay" datatype="html">
+        <source>Customers have very different abilities to pay, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br class=&quot;d-none d-md-block&quot; /&gt;"/> so we have an honor-based pricing model.</source>
+        <target state="needs-translation">Klienci mają bardzo różne zdolności do płacenia, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br class=&quot;d-none d-md-block&quot; /&gt;"/> więc mamy model cenowy oparty na honorze.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">12,15</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="youCanChooseYourIdealPrice" datatype="html">
+        <source>You can choose your ideal price point then take a discount you need to afford Maptio.</source>
+        <target state="translated">Możesz wybrać idealny punkt cenowy, a następnie skorzystać ze zniżki, której potrzebujesz, aby pozwolić sobie na Maptio.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">122,124</context>
         </context-group>
       </trans-unit>
     </body>

--- a/apps/maptio/src/locale/messages.pl.xlf
+++ b/apps/maptio/src/locale/messages.pl.xlf
@@ -2647,28 +2647,12 @@
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
-        <source>Starter</source>
-        <target state="translated">Starter</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
         <source>Larger organizations</source>
         <target state="translated">Większe organizacje</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">119</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">
-        <source>Struggling to afford this? Let's talk and work something out. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Contact us.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Our mission is to serve the most cause-driven organizations on the planet. Discounts available for non-profits.</source>
-        <target state="translated">Nie stać cię na to? Porozmawiajmy i znajdźmy rozwiązanie. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Skontaktuj się z nami.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Naszą misją jest służyć najbardziej pro-społecznym organizacjom na świecie. Zniżki dostępne dla organizacji non-profit.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">127,133</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9d27d4f27b5aaef466a1168019027952abd5cbe5" datatype="html">
@@ -3189,7 +3173,7 @@
       </trans-unit>
       <trans-unit id="heroesPlanDescription" datatype="html">
         <source>35 - 250 people in <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> commercial initiatives and <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> well-funded non-profits</source>
-        <target state="needs-translation">35 - 250 osób w &lt;x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/&gt; inicjatywach komercyjnych i &lt;x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/&gt; dobrze finansowanych organizacjach non-profit</target>
+        <target state="translated">35 - 250 osób w <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> inicjatywach komercyjnych i <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> dobrze finansowanych organizacjach non-profit</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">104,109</context>
@@ -3245,7 +3229,7 @@
       </trans-unit>
       <trans-unit id="discountCodes20love40help" datatype="html">
         <source>20% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>love<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 40% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>help<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>
-        <target state="needs-translation">20% zniżki: użyj kodu &lt;x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/&gt;love&lt;x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/&gt;&lt;x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/&gt; 40% zniżki: użyj kodu &lt;x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/&gt;help&lt;x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/&gt;</target>
+        <target state="translated">20% zniżki: użyj kodu <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>love<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 40% zniżki: użyj kodu <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>help<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">127,131</context>

--- a/apps/maptio/src/locale/messages.pt.xlf
+++ b/apps/maptio/src/locale/messages.pt.xlf
@@ -91,17 +91,6 @@
           <context context-type="linenumber">280</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
-        <source>Pricing</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">283</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
         <source>Copyright</source>
         <context-group purpose="location">

--- a/apps/maptio/src/locale/messages.xlf
+++ b/apps/maptio/src/locale/messages.xlf
@@ -921,32 +921,46 @@
         <source>per month, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> per organization</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">15,18</context>
+          <context context-type="linenumber">17,20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="contactUs" datatype="html">
         <source>Contact us</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">28</context>
+          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">72</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="intendedFor" datatype="html">
+        <source>Intended for:</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="14dayFreeTrialDiscountsAvailable" datatype="html">
+        <source>14 Day free trial <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Discounts available</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
+          <context context-type="linenumber">43,46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="signUp" datatype="html">
         <source>Sign up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">41</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="subscribe" datatype="html">
         <source>Subscribe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">49</context>
+          <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
       <trans-unit id="customersHaveDifferentAbilitiesToPay" datatype="html">
@@ -984,88 +998,88 @@
           <context context-type="linenumber">36,39</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
-        <source>Starter</source>
+      <trans-unit id="908d8a67826fc56e92aba7638b795d73b23fbaaf" datatype="html">
+        <source>Strivers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
           <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
-        <source>1 - 12 people</source>
+      <trans-unit id="striversPlanDescription" datatype="html">
+        <source>individuals, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> tiny teams, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> and the cash-poor</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">69,74</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
-        <source>Small</source>
+      <trans-unit id="284f7a5a4e600a530964c571e426db23cd76b4fb" datatype="html">
+        <source>Pioneers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
-        <source>13 - 35 people</source>
+      <trans-unit id="pioneersPlanDescription" datatype="html">
+        <source>small teams of 10-35 people <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> and non-profits <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">73</context>
+          <context context-type="linenumber">90,93</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
-        <source>Standard plan</source>
+      <trans-unit id="33a29e29d6c1ae044e8e3350733a49c8dbeb18af" datatype="html">
+        <source>Heroes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
-        <source>36 - 200 people</source>
+      <trans-unit id="heroesPlanDescription" datatype="html">
+        <source>35 - 250 people in <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> commercial initiatives and <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> well-funded non-profits</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">110,115</context>
         </context-group>
       </trans-unit>
       <trans-unit id="discounts" datatype="html">
         <source>Discounts</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">121</context>
         </context-group>
       </trans-unit>
       <trans-unit id="asACauseDrivenCompany" datatype="html">
         <source>As a cause-driven company we don't want money to be a barrier for anyone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">110,111</context>
+          <context context-type="linenumber">124,125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="youCanChooseYourIdealPrice" datatype="html">
         <source>You can choose your ideal price point then take a discount you need to afford Maptio.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">114,116</context>
+          <context context-type="linenumber">128,130</context>
         </context-group>
       </trans-unit>
       <trans-unit id="discountCodes20love40help" datatype="html">
         <source>20% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>love<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 40% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>help<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">119,123</context>
+          <context context-type="linenumber">133,137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="pleaseSupportTheDevelopmentOfMaptio" datatype="html">
         <source>Please support the development of Maptio by only taking off what you really need.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">127,129</context>
+          <context context-type="linenumber">141,143</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tryMaptioForFree" datatype="html">
         <source>Try Maptio for free</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">141,142</context>
+          <context context-type="linenumber">155,156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="noPermission" datatype="html">

--- a/apps/maptio/src/locale/messages.xlf
+++ b/apps/maptio/src/locale/messages.xlf
@@ -921,46 +921,46 @@
         <source>per month, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> per organization</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">17,20</context>
+          <context context-type="linenumber">21,24</context>
         </context-group>
       </trans-unit>
       <trans-unit id="contactUs" datatype="html">
         <source>Contact us</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">34</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">76</context>
         </context-group>
       </trans-unit>
       <trans-unit id="intendedFor" datatype="html">
         <source>Intended for:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">35</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="14dayFreeTrialDiscountsAvailable" datatype="html">
         <source>14 Day free trial <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Discounts available</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">43,46</context>
+          <context context-type="linenumber">47,50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="signUp" datatype="html">
         <source>Sign up</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">56</context>
+          <context context-type="linenumber">60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="subscribe" datatype="html">
         <source>Subscribe</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/payment-plan.component.html</context>
-          <context context-type="linenumber">64</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
       <trans-unit id="customersHaveDifferentAbilitiesToPay" datatype="html">
@@ -1009,77 +1009,77 @@
         <source>individuals, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> tiny teams, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> and the cash-poor</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">69,74</context>
+          <context context-type="linenumber">67,72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="284f7a5a4e600a530964c571e426db23cd76b4fb" datatype="html">
         <source>Pioneers</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">77</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit>
       <trans-unit id="pioneersPlanDescription" datatype="html">
         <source>small teams of 10-35 people <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> and non-profits <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">90,93</context>
+          <context context-type="linenumber">86,89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="33a29e29d6c1ae044e8e3350733a49c8dbeb18af" datatype="html">
         <source>Heroes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">93</context>
         </context-group>
       </trans-unit>
       <trans-unit id="heroesPlanDescription" datatype="html">
         <source>35 - 250 people in <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> commercial initiatives and <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> well-funded non-profits</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">110,115</context>
+          <context context-type="linenumber">104,109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="discounts" datatype="html">
         <source>Discounts</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">115</context>
         </context-group>
       </trans-unit>
       <trans-unit id="asACauseDrivenCompany" datatype="html">
         <source>As a cause-driven company we don't want money to be a barrier for anyone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">124,125</context>
+          <context context-type="linenumber">118,119</context>
         </context-group>
       </trans-unit>
       <trans-unit id="youCanChooseYourIdealPrice" datatype="html">
         <source>You can choose your ideal price point then take a discount you need to afford Maptio.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">128,130</context>
+          <context context-type="linenumber">122,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="discountCodes20love40help" datatype="html">
         <source>20% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>love<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 40% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>help<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">133,137</context>
+          <context context-type="linenumber">127,131</context>
         </context-group>
       </trans-unit>
       <trans-unit id="pleaseSupportTheDevelopmentOfMaptio" datatype="html">
         <source>Please support the development of Maptio by only taking off what you really need.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">141,143</context>
+          <context context-type="linenumber">135,137</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tryMaptioForFree" datatype="html">
-        <source>Try Maptio for free</source>
+        <source>Try Maptio for FREE</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">155,156</context>
+          <context context-type="linenumber">149,150</context>
         </context-group>
       </trans-unit>
       <trans-unit id="noPermission" datatype="html">

--- a/apps/maptio/src/locale/messages.xlf
+++ b/apps/maptio/src/locale/messages.xlf
@@ -59,7 +59,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">275</context>
+          <context context-type="linenumber">270</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3c78b53bca33467190c0b7a01320bc093a2b1427" datatype="html">
@@ -77,7 +77,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">286</context>
+          <context context-type="linenumber">281</context>
         </context-group>
       </trans-unit>
       <trans-unit id="85b79c9064aed1ead31ace985f31aa1363f6bdaf" datatype="html">
@@ -87,11 +87,23 @@
           <context context-type="linenumber">21</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="b051eeff3ae30cba4fbd1885ebb58fc22fb0d587" datatype="html">
+      <trans-unit id="pricing" datatype="html">
         <source>Pricing</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/footer/footer.component.html</context>
           <context context-type="linenumber">25</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
+          <context context-type="linenumber">68</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
+          <context context-type="linenumber">295</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">7</context>
         </context-group>
       </trans-unit>
       <trans-unit id="cc82fa89983785cb60daa0a7516c611fc02b5cd1" datatype="html">
@@ -126,65 +138,54 @@
           <context context-type="linenumber">290,291</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="pricing" datatype="html">
-        <source>Pricing</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">73,74</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">295,296</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="f2d11ba5c599061eca2405ac09dc467f7c3adbcf" datatype="html">
         <source>Settings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">83,84</context>
+          <context context-type="linenumber">78,79</context>
         </context-group>
       </trans-unit>
       <trans-unit id="595aff5564b0119a1eeda9b4d7aaf21c5da69de3" datatype="html">
         <source>Maps</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">97</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">223</context>
+          <context context-type="linenumber">218</context>
         </context-group>
       </trans-unit>
       <trans-unit id="994363f08f9fbfa3b3994ff7b35c6904fdff18d8" datatype="html">
         <source>Profile</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">153</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">216</context>
+          <context context-type="linenumber">211</context>
         </context-group>
       </trans-unit>
       <trans-unit id="organisations" datatype="html">
         <source>Organisations</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">164</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a3a1d87649a0bcfe77259b11af7621e6f2c25912" datatype="html">
         <source>More ...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">176</context>
+          <context context-type="linenumber">171</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6326f9ce2365bfe97668c4aa146fbbb762497c1a" datatype="html">
         <source>Log out</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">197,198</context>
+          <context context-type="linenumber">192,193</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
@@ -195,7 +196,7 @@
         <source>Log in</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">206</context>
+          <context context-type="linenumber">201</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/home/pages/home/home.page.html</context>
@@ -206,28 +207,28 @@
         <source>All maps ...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">240</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="499e340c6f959d401d9e027e4d78f1cb19f66c6e" datatype="html">
         <source>Organizations</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">248,249</context>
+          <context context-type="linenumber">243,244</context>
         </context-group>
       </trans-unit>
       <trans-unit id="b4d7491d66bd2a5eb3cea884df1b365cd1909faf" datatype="html">
         <source>All organizations...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">267,268</context>
+          <context context-type="linenumber">262,263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="13fed01b1b423a92af56a1bad816a7d73e702f2b" datatype="html">
         <source>Privacy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/core/header/header.component.html</context>
-          <context context-type="linenumber">279,280</context>
+          <context context-type="linenumber">274,275</context>
         </context-group>
       </trans-unit>
       <trans-unit id="eff51037b421db3615f783b54c102a4187f998e1" datatype="html">
@@ -948,106 +949,123 @@
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="chooseYourPlan" datatype="html">
-        <source>Choose your plan</source>
+      <trans-unit id="customersHaveDifferentAbilitiesToPay" datatype="html">
+        <source>Customers have very different abilities to pay, <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br class=&quot;d-none d-md-block&quot; /&gt;"/> so we have an honor-based pricing model.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">9,10</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">15,16</context>
+          <context context-type="linenumber">12,15</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="fae28db5960f6ec8a618b29d7c245fed8d8e0f05" datatype="html">
-        <source>Get started - try Maptio for free</source>
+      <trans-unit id="ourCauseIsToServe" datatype="html">
+        <source>Our cause is to serve as many other cause-driven initiatives as possible.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">26,27</context>
+          <context context-type="linenumber">21,22</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="0948acbf2eb00c73d4eb4d6b2066a8044dd018b8" datatype="html">
-        <source>Pricing in US Dollars. All major credit cards accepted. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> No minimum contract length.</source>
+      <trans-unit id="weTrustYouToPay" datatype="html">
+        <source>We trust you to pay the right amount for you.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">31,34</context>
+          <context context-type="linenumber">25,26</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="beb13b8cf46197116e7cfc1d65c7c20b9dc9b43a" datatype="html">
-        <source>Annual billing</source>
+      <trans-unit id="pleaseHelpFundUs" datatype="html">
+        <source>Please help fund us to improve Maptio for everyone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">51</context>
+          <context context-type="linenumber">29,30</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c5376ad5fd8f2dece083dd9b46151312173e76c1" datatype="html">
-        <source>Monthly billing</source>
+      <trans-unit id="youCanChooseYourOwnPrice" datatype="html">
+        <source>You can choose your own price level. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br class=&quot;d-none d-md-block&quot; /&gt;"/> All levels have full access to Maptio.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">63</context>
+          <context context-type="linenumber">36,39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6b1ba85935a3d891a1e1b961ab11f4dd8d7052f6" datatype="html">
         <source>Starter</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">71</context>
+          <context context-type="linenumber">56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="02f64e0dada8db77cf246b82054d1a7d81557567" datatype="html">
         <source>1 - 12 people</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">72</context>
+          <context context-type="linenumber">57</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4df6f726a512cf8846e5ead65423bb4121d3d379" datatype="html">
         <source>Small</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">87</context>
+          <context context-type="linenumber">72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="a1701a60ba8fe1e302b632bf9f04cf86a6450ad2" datatype="html">
         <source>13 - 35 people</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">88</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="0f65f2db1ec58eba243cde556ab7b20b82826ff5" datatype="html">
         <source>Standard plan</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">103</context>
+          <context context-type="linenumber">88</context>
         </context-group>
       </trans-unit>
       <trans-unit id="d207d07b14a509f32cc198bdcf1dec65ce3c05ba" datatype="html">
         <source>36 - 200 people</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">104</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="083be8d4a1c487c222a248a1d6a9a5b6dbbb596f" datatype="html">
-        <source>Larger organizations</source>
+      <trans-unit id="discounts" datatype="html">
+        <source>Discounts</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6695dcc9f3e85f97fc1b47b4e353875a20f7c543" datatype="html">
-        <source>200+ people</source>
+      <trans-unit id="asACauseDrivenCompany" datatype="html">
+        <source>As a cause-driven company we don't want money to be a barrier for anyone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">110,111</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="9ff2e34a90a800108fb0ba0393cfdf1c3db2c258" datatype="html">
-        <source>Struggling to afford this? Let's talk and work something out. <x id="START_LINK" ctype="x-a" equiv-text="&lt;a href=&quot;mailto:support@maptio.com?subject=Deal request&quot;&gt;"/>Contact us.<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> Our mission is to serve the most cause-driven organizations on the planet. Discounts available for non-profits.</source>
+      <trans-unit id="youCanChooseYourIdealPrice" datatype="html">
+        <source>You can choose your ideal price point then take a discount you need to afford Maptio.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
-          <context context-type="linenumber">127,133</context>
+          <context context-type="linenumber">114,116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="discountCodes20love40help" datatype="html">
+        <source>20% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>love<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/><x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br /&gt;"/> 40% off: use code <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>help<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">119,123</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="pleaseSupportTheDevelopmentOfMaptio" datatype="html">
+        <source>Please support the development of Maptio by only taking off what you really need.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">127,129</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tryMaptioForFree" datatype="html">
+        <source>Try Maptio for free</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">apps/maptio/src/app/modules/payment/pages/pricing/pricing.page.html</context>
+          <context context-type="linenumber">141,142</context>
         </context-group>
       </trans-unit>
       <trans-unit id="noPermission" datatype="html">


### PR DESCRIPTION
As per title - just changes required to make the in-app pricing page the same as the new pricing experiment page on the Maptio website.