### PR TITLE
Fix Intercom sync by adding user ID to server-side Intercom API call

### DIFF
--- a/apps/maptio-server/src/routes/intercom.js
+++ b/apps/maptio-server/src/routes/intercom.js
@@ -14,11 +14,14 @@ const INTERCOM_ACCESS_TOKEN = process.env.INTERCOM_ACCESS_TOKEN;
 var client = new Intercom.Client({ token: INTERCOM_ACCESS_TOKEN });
 
 router.post('/user/update', function (req, res, next) {
+  let user_id = req.body.user_id;
   let email = req.body.email;
   let company = req.body.company;
+
   client.users.update(
     {
-      email: email,
+      user_id,
+      email,
       companies: [company],
     },
     function (error, user) {

--- a/apps/maptio/src/app/shared/services/team/intercom.service.ts
+++ b/apps/maptio/src/app/shared/services/team/intercom.service.ts
@@ -13,8 +13,8 @@ export class IntercomService {
 
   createTeam(user: User, team: Team): Observable<boolean> {
     const userUpdatePayload = {
-      email: user.email,
       user_id: user.user_id,
+      email: user.email,
       company: {
         company_id: team.team_id,
         name: team.name,


### PR DESCRIPTION
This is a follow-up to #801 - that attempt at fixing the intercom was unsuccessful - for a simple reason - I didn't pass on the `user_id` to the server-side call to the intercom API, duh!