### PR TITLE
Update design of expanded map

### DIFF
--- a/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.html
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.html
@@ -5,14 +5,14 @@
   fill="none"
 />
 
-<svg:text fill="white" stroke-width="0" font-size="3rem" font-weight="600">
+<svg:text fill="white" stroke-width="0" font-size="3.5rem" font-weight="600">
   <textPath
     #name
     xlink:href="#circleEdge"
     startOffset="50%"
     text-anchor="middle"
   >
-    <tspan dy="46">{{ circle.data.name }}</tspan>
+    <tspan dy="59">{{ circle.data.name }}</tspan>
 
     <!-- This is here to move the following tspans -->
     <tspan dy="-15">&nbsp;</tspan>

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.html
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.html
@@ -29,11 +29,5 @@
   *ngFor="let person of people; let i = index"
   maptioHelperAvatarSvg
   [helper]="person"
-  [attr.transform]="
-    'translate(' +
-    (radius - 45) * math.sin(0.2 * (i + 0.5 - people.length / 2)) +
-    ',' +
-    (radius - 45) * math.cos(0.2 * (i + 0.5 - people.length / 2)) +
-    ')'
-  "
+  [attr.transform]="person.position"
 ></svg:g>

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.ts
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.ts
@@ -14,9 +14,6 @@ export class CircleInfoSvgComponent implements OnInit {
   tags: TagViewModel[] = [];
   people: Helper[] = [];
 
-  // TODO: Move calculations into typescript code
-  math = Math;
-
   ngOnInit() {
     this.people = this.combineAllPeople();
     this.people = this.calculateAvatarPositions(this.people);

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.ts
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle-info-svg/circle-info-svg.component.ts
@@ -19,6 +19,7 @@ export class CircleInfoSvgComponent implements OnInit {
 
   ngOnInit() {
     this.people = this.combineAllPeople();
+    this.people = this.calculateAvatarPositions(this.people);
   }
 
   private combineAllPeople(): Helper[] {
@@ -28,6 +29,19 @@ export class CircleInfoSvgComponent implements OnInit {
       people = [this.circle.data.accountable];
     }
     people = people.concat(this.circle.data.helpers);
+
+    return people;
+  }
+
+  private calculateAvatarPositions(people: Helper[]) {
+    people.forEach((person, index) => {
+      person.position =
+        'translate(' +
+        (this.radius - 45) * Math.sin(0.2 * (index + 0.5 - people.length / 2)) +
+        ',' +
+        (this.radius - 45) * Math.cos(0.2 * (index + 0.5 - people.length / 2)) +
+        ')';
+    });
 
     return people;
   }

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle-info/circle-info.component.ts
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle-info/circle-info.component.ts
@@ -11,7 +11,7 @@ import { InitiativeNode } from '../initiative.model';
 export class CircleInfoComponent implements OnInit {
   @Input() circle!: InitiativeNode;
 
-  fontSizeInitial = 72;
+  fontSizeInitial = 56;
   fontSizeUnit = 'px'; // Using pixels rather than rem leads to better rendering at small sizes
   fontSizeScalingFactor = 4;
   fontSize: string;

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle-map-expanded.component.ts
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle-map-expanded.component.ts
@@ -55,7 +55,8 @@ export class CircleMapExpandedComponent implements OnInit, OnDestroy {
   showDescriptions$: Observable<boolean>;
 
   // And we need to scale down child circles to make room for circle info
-  scalingFactor = 0.9;
+  // This specific number was chosen to ensure enough space above and below avatars
+  scalingFactor = 0.853;
 
   isLoading: boolean;
   isFirstLoad = true;

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
@@ -1,8 +1,9 @@
-$info-scale-selected-not-hovered: 0.995;
-$info-scale-selected: 0.99;
-
 $stroke-width-selected-not-hovered: 0.25rem;
 $stroke-width-selected: 0.375rem;
+
+$opacity-default: 1;
+$opacity-filtered-out: 0.15;
+$opacity-not-hovered: 0.5;
 
 $shadow-filter-blur: 0.75rem;
 $shadow-opacity-default: 0;
@@ -32,30 +33,30 @@ $shadow-scale-selected: 1.004;
 .circle__shadow {
   display: none;
   opacity: $shadow-opacity-default;
-  // filter: blur($shadow-filter-blur);
+  transform: scale($shadow-scale-default);
   filter: drop-shadow(0 0 $shadow-filter-blur gray);
   transition: opacity 0.2s ease-in;
   transition: transform 0.2s ease-in;
 }
 
 .circle--state-filtered-out {
-  fill-opacity: 0.15;
+  fill-opacity: $opacity-filtered-out;
 
   > .circle__info {
-    opacity: 0.15;
+    opacity: $opacity-filtered-out;
   }
 }
 
 .circle:not(.circle--state-filtered-out) {
-  fill-opacity: 1;
+  fill-opacity: $opacity-default;
 
   > .circle__info {
-    opacity: 1;
+    opacity: $opacity-default;
   }
 }
 
 .circle--state-selected {
-  fill-opacity: 1;
+  fill-opacity: $opacity-default;
   pointer-events: auto;
 
   > .circle__circle {
@@ -70,32 +71,34 @@ $shadow-scale-selected: 1.004;
   }
 
   > .circle__info {
-    opacity: 1;
+    opacity: $opacity-default;
     pointer-events: auto;
-    // transform: scale($info-scale-selected-not-hovered);
   }
 }
 
 .circle:has(.circle:hover) {
   .circle__circle {
-    fill-opacity: 0.5;
+    fill-opacity: $opacity-not-hovered;
   }
 
   .circle__info {
-    opacity: 0.5;
+    opacity: $opacity-not-hovered;
   }
 }
 
-// .circle > .circle__children > g > .circle:hover {
+// For hover effects isolated to a single circle, with the current nested SVG
+// structure, we need to check that only circles without children that are also
+// being hovered over, i.e. that we're selecting only the topmost hovered
+// circle
 .circle:not(:has(.circle:hover)):hover {
-  opacity: 1;
+  opacity: $opacity-default;
 
   > .circle__circle {
     stroke-width: $stroke-width-selected;
   }
 
   .circle__circle {
-    fill-opacity: 1;
+    fill-opacity: $opacity-default;
   }
 
   > .circle__shadow {
@@ -105,109 +108,9 @@ $shadow-scale-selected: 1.004;
   }
 
   .circle__info {
-    opacity: 1;
-    //   transform: scale($info-scale-selected);
+    opacity: $opacity-default;
   }
 }
-
-// .circle--state-selected:not(.circle--state-opened):hover {
-//   > .circle__circle {
-//     stroke-width: $stroke-width-selected;
-//   }
-
-//   > .circle__shadow {
-//     display: inline;
-//     opacity: $shadow-opacity-selected;
-//     transform: scale($shadow-scale-selected);
-//   }
-
-//   > .circle__info {
-//     transform: scale($info-scale-selected);
-//   }
-// }
-
-// .circle--state-opened > .circle__circle {
-//   fill-opacity: 0.6;
-//   stroke-width: $stroke-width-selected-not-hovered;
-// }
-
-// .circle--state-opened > .circle__shadow {
-//   opacity: $shadow-opacity-selected-not-hovered;
-//   fill-opacity: 0.6;
-//   transform: scale($shadow-scale-default);
-// }
-
-// .circle--state-opened > .circle__info {
-//   transform: scale(1);
-// }
-
-// .circle--state-selected > .circle__children > g > .circle {
-//   > .circle__info {
-//     opacity: 0.1;
-//   }
-// }
-
-// .circle--state-opened:not(.circle--type-leaf) {
-//   fill-opacity: 0.15;
-
-//   > .circle__info {
-//     opacity: 0;
-//     pointer-events: none;
-//     transform: scale(1.25);
-//   }
-// }
-
-// .circle--state-opened > .circle__children > g > .circle {
-//   fill-opacity: 1;
-//   pointer-events: auto;
-
-//   > .circle__shadow {
-//     display: inline;
-//     opacity: $shadow-opacity-selected-not-hovered;
-//     transform: scale($shadow-scale-selected-not-hovered);
-//   }
-
-//   > .circle__info {
-//     opacity: 1;
-//     pointer-events: auto;
-//   }
-// }
-
-// // https://codepen.io/shshaw/pen/wWQZEB
-
-// .circle--state-opened > .circle__children {
-//   visibility: hidden;
-// }
-
-// .circle--state-opened > .circle__children > g {
-//   visibility: visible;
-// }
-
-// .circle--state-opened > .circle__children:hover > g > .circle {
-//   opacity: 0.4;
-
-//   > .circle__shadow {
-//     transform: scale($shadow-scale-selected-not-hovered);
-//     opacity: $shadow-opacity-selected-not-hovered;
-//   }
-// }
-
-// .circle--state-opened > .circle__children:hover > g:hover > .circle {
-//   opacity: 1;
-
-//   > .circle__circle {
-//     stroke-width: $stroke-width-selected;
-//   }
-
-//   > .circle__shadow {
-//     transform: scale($shadow-scale-selected);
-//     opacity: $shadow-opacity-selected;
-//   }
-
-//   > .circle__info {
-//     transform: scale($info-scale-selected);
-//   }
-// }
 
 .circle__popover {
   // Styles copied from .mat-tooltip @ 11.2.8

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
@@ -39,23 +39,7 @@ $shadow-scale-selected: 1.004;
   transition: transform 0.2s ease-in;
 }
 
-.circle--state-filtered-out {
-  fill-opacity: $opacity-filtered-out;
-
-  > .circle__info {
-    opacity: $opacity-filtered-out;
-  }
-}
-
-.circle:not(.circle--state-filtered-out) {
-  fill-opacity: $opacity-default;
-
-  > .circle__info {
-    opacity: $opacity-default;
-  }
-}
-
-.circle--state-selected {
+.circle--state-selected:not(.circle--state-filtered-out) {
   fill-opacity: $opacity-default;
   pointer-events: auto;
 
@@ -95,9 +79,6 @@ $shadow-scale-selected: 1.004;
 
   > .circle__circle {
     stroke-width: $stroke-width-selected;
-  }
-
-  .circle__circle {
     fill-opacity: $opacity-default;
   }
 
@@ -107,8 +88,20 @@ $shadow-scale-selected: 1.004;
     transform: scale($shadow-scale-selected);
   }
 
-  .circle__info {
+  > .circle__info {
     opacity: $opacity-default;
+  }
+}
+
+.circle--state-filtered-out {
+  > .circle__circle {
+    fill-opacity: $opacity-filtered-out !important;
+    pointer-events: none;
+  }
+
+  > .circle__info {
+    opacity: $opacity-filtered-out !important;
+    pointer-events: none;
   }
 }
 

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
@@ -52,27 +52,27 @@ $shadow-scale-selected: 1.008;
   }
 }
 
-// .circle--state-selected {
-//   fill-opacity: 1;
-//   pointer-events: auto;
+.circle--state-selected {
+  fill-opacity: 1;
+  pointer-events: auto;
 
-//   > .circle__circle {
-//     stroke: white;
-//     stroke-width: $stroke-width-selected-not-hovered;
-//   }
+  > .circle__circle {
+    stroke: white;
+    stroke-width: $stroke-width-selected-not-hovered;
+  }
 
-//   > .circle__shadow {
-//     display: inline;
-//     opacity: $shadow-opacity-selected-not-hovered;
-//     transform: scale($shadow-scale-selected-not-hovered);
-//   }
+  > .circle__shadow {
+    display: inline;
+    opacity: $shadow-opacity-selected-not-hovered;
+    transform: scale($shadow-scale-selected-not-hovered);
+  }
 
-//   > .circle__info {
-//     opacity: 1;
-//     pointer-events: auto;
-//     transform: scale($info-scale-selected-not-hovered);
-//   }
-// }
+  > .circle__info {
+    opacity: 1;
+    pointer-events: auto;
+    transform: scale($info-scale-selected-not-hovered);
+  }
+}
 
 // .circle--state-selected:not(.circle--state-opened):hover {
 //   > .circle__circle {

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
@@ -3,7 +3,7 @@ $stroke-width-selected: 0.375rem;
 
 $opacity-default: 1;
 $opacity-filtered-out: 0.15;
-$opacity-not-hovered: 0.5;
+$opacity-not-hovered: 0.65;
 
 $shadow-filter-blur: 0.75rem;
 $shadow-opacity-default: 0;

--- a/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
+++ b/apps/maptio/src/app/modules/circle-map-expanded/circle/circle.component.scss
@@ -1,15 +1,17 @@
-$info-scale-selected-not-hovered: 0.975;
-$info-scale-selected: 0.95;
+$info-scale-selected-not-hovered: 0.995;
+$info-scale-selected: 0.99;
+
 $stroke-width-selected-not-hovered: 0.25rem;
-$stroke-width-selected: 0.625rem;
+$stroke-width-selected: 0.375rem;
 
 $shadow-filter-blur: 0.75rem;
 $shadow-opacity-default: 0;
 $shadow-opacity-selected-not-hovered: 0.75;
 $shadow-opacity-selected: 1;
+
 $shadow-scale-default: 1;
 $shadow-scale-selected-not-hovered: 1;
-$shadow-scale-selected: 1.008;
+$shadow-scale-selected: 1.004;
 
 .circle {
   cursor: pointer;
@@ -70,7 +72,41 @@ $shadow-scale-selected: 1.008;
   > .circle__info {
     opacity: 1;
     pointer-events: auto;
-    transform: scale($info-scale-selected-not-hovered);
+    // transform: scale($info-scale-selected-not-hovered);
+  }
+}
+
+.circle:has(.circle:hover) {
+  .circle__circle {
+    fill-opacity: 0.5;
+  }
+
+  .circle__info {
+    opacity: 0.5;
+  }
+}
+
+// .circle > .circle__children > g > .circle:hover {
+.circle:not(:has(.circle:hover)):hover {
+  opacity: 1;
+
+  > .circle__circle {
+    stroke-width: $stroke-width-selected;
+  }
+
+  .circle__circle {
+    fill-opacity: 1;
+  }
+
+  > .circle__shadow {
+    display: inline;
+    opacity: $shadow-opacity-selected;
+    transform: scale($shadow-scale-selected);
+  }
+
+  .circle__info {
+    opacity: 1;
+    //   transform: scale($info-scale-selected);
   }
 }
 

--- a/apps/maptio/src/app/modules/circle-map-expanded/helper-avatar-svg/helper-avatar-svg.component.html
+++ b/apps/maptio/src/app/modules/circle-map-expanded/helper-avatar-svg/helper-avatar-svg.component.html
@@ -13,6 +13,7 @@
     clip-path="url(#avatar-clip-path)"
     [satPopoverAnchor]="popover"
     [satPopoverHover]="300"
+    (click)="onClick($event)"
   />
 </svg:g>
 

--- a/apps/maptio/src/app/modules/circle-map-expanded/helper-avatar-svg/helper-avatar-svg.component.html
+++ b/apps/maptio/src/app/modules/circle-map-expanded/helper-avatar-svg/helper-avatar-svg.component.html
@@ -1,14 +1,14 @@
 <svg:g>
   <clipPath id="avatar-clip-path">
-    <circle cx="0" cy="0" r="40" />
+    <circle cx="0" cy="0" r="39" />
   </clipPath>
 
   <image
     [attr.xlink:href]="helper.picture"
-    x="-40"
-    y="-40"
-    width="80"
-    height="80"
+    x="-39"
+    y="-39"
+    width="78"
+    height="78"
     preserveAspectRatio="xMidYMid slice"
     clip-path="url(#avatar-clip-path)"
     [satPopoverAnchor]="popover"

--- a/apps/maptio/src/app/modules/circle-map-expanded/initiative.model.ts
+++ b/apps/maptio/src/app/modules/circle-map-expanded/initiative.model.ts
@@ -29,6 +29,7 @@ export interface Helper {
   shortid: string;
   picture: string;
   name: string;
+  position: string;
   roles: Array<Role>;
 }
 

--- a/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.html
@@ -93,7 +93,7 @@
 
               <button
                 class="btn btn-light toolbar-button p-1 text-dark d-flex flex-column justify-content-between align-items-center"
-                [class.disabled]="isFilterDisabled || isMapSettingsDisabled"
+                [class.disabled]="isMapSettingsDisabled"
                 (click)="isFiltersToggled = !isFiltersToggled"
                 data-toggle="collapse"
                 href="#collapseFilter"
@@ -269,6 +269,8 @@
       class="collapse rounded mb-3 col-12 bg-light p-3"
     >
       <filter-tags
+        [isFilterDisabled]="this.isFilterDisabled"
+        [expandedMapLink]="'/map/' + datasetId + '/' + slug + '/expanded'"
         [team]="team"
         [tags]="tags"
         (changeTagsSelection)="broadcastTagsSelection($event)"

--- a/apps/maptio/src/app/modules/workspace/components/filtering/tags.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/filtering/tags.component.html
@@ -1,4 +1,7 @@
-<div class="card bg-transparent border-0">
+<div
+  class="card bg-transparent border-0"
+  *ngIf="!isFilterDisabled; else filterDisabledMessage"
+>
   <div class="card-body">
     <div class="d-flex flex-wrap">
       <span *ngFor="let tag of tags; let i = index" class="mr-1 my-1">
@@ -43,3 +46,19 @@
     </button>
   </div>
 </div>
+
+<ng-template #filterDisabledMessage>
+  <h3 class="editing-title" i18n>Please use the expanded view</h3>
+
+  <p i18n>
+    The expanded view is more suitable for filtering by tags. Please navigate
+    there by choosing the expanded view from the toolbar or clicking the button
+    below.
+  </p>
+
+  <div class="d-flex flex-row w-100 mt-3 justify-content-end">
+    <button class="btn btn-success" [routerLink]="expandedMapLink">
+      <ng-container i18n="@@takeMeThere">Take me there</ng-container>
+    </button>
+  </div>
+</ng-template>

--- a/apps/maptio/src/app/modules/workspace/components/filtering/tags.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/filtering/tags.component.ts
@@ -11,7 +11,7 @@ import { Angulartics2Mixpanel } from 'angulartics2/mixpanel';
 })
 export class FilterTagsComponent implements OnInit {
   @Input() isFilterDisabled: boolean;
-  @Input() expandedMapLink: boolean;
+  @Input() expandedMapLink: string;
   @Input() tags: SelectableTag[];
   @Input() team: Team;
   @Output() changeTagsSettings: EventEmitter<

--- a/apps/maptio/src/app/modules/workspace/components/filtering/tags.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/filtering/tags.component.ts
@@ -10,6 +10,8 @@ import { Angulartics2Mixpanel } from 'angulartics2/mixpanel';
   // styleUrls: ["./tags.component.css"]
 })
 export class FilterTagsComponent implements OnInit {
+  @Input() isFilterDisabled: boolean;
+  @Input() expandedMapLink: boolean;
   @Input() tags: SelectableTag[];
   @Input() team: Team;
   @Output() changeTagsSettings: EventEmitter<


### PR DESCRIPTION
Addressed the following four tasks from #797 (i.e. the "Let's do this next" section):
* First step to improving performance: move geometrical calculations out of the template
* Correct font and avatar sizing to match the leaf nodes / gradually revealing map and to make the tags take up less space
* Bring back styling for selected circles and on hover (that only needs to be adapted from the gradually revealing map styles, but should mostly all work fine, so this is a small task)
* On the expanded map, bring back the filter button and add a message explaining that filtering by tags is available on the expanded map (is this even still needed if we're making this view the default?)
* Clicking on the SVG avatars should open up the directory just like clicking on the avatars on the non-expanded map does (and on the circle info of leaf nodes in the expanded map too!)

The one task that took ages was the one where I wrote "this is a small task." Argh.