### PR TITLE
Fix translation causing circle delete error

### DIFF
--- a/apps/maptio/src/locale/messages.ja.xlf
+++ b/apps/maptio/src/locale/messages.ja.xlf
@@ -1895,7 +1895,7 @@
       </trans-unit>
       <trans-unit id="6b3a6c8d7c361e6f48e91b986e36949103788c83" datatype="html">
         <source>Circle <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/><x id="INTERPOLATION" equiv-text="{{ initiativeToBeDeleted.name }}"/><x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> will be deleted <x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>along with its sub-circles<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> .</source>
-        <target state="translated">サークル<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/><x id="INTERPOLATION" equiv-text="{{ initiativeToBeDeleted.name }}"/><x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> は、そのサブサークル<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> と共に<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/>に削除されます。</target>
+        <target state="translated">サークル<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/><x id="INTERPOLATION" equiv-text="{{ initiativeToBeDeleted.name }}"/><x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/> は、そのサブサークル<x id="START_BOLD_TEXT" ctype="x-b" equiv-text="&lt;b&gt;"/> と共に<x id="CLOSE_BOLD_TEXT" ctype="x-b" equiv-text="&lt;/b&gt;"/>に削除されます。</target>
         <context-group purpose="location">
           <context context-type="sourcefile">apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html</context>
           <context context-type="linenumber">154,159</context>


### PR DESCRIPTION
### Issue
https://app.intercom.com/a/inbox/q3x5lnhp/inbox/shared/all/conversation/106323200006124?view=List

### Description
In one of the translations code tags were mismatched leading to an error in deleting circles. Correcting the translation fixes the issue.