### PR TITLE
Make getting users by email case insensitive

### DIFF
--- a/apps/maptio-server/src/routes/users.js
+++ b/apps/maptio-server/src/routes/users.js
@@ -40,13 +40,16 @@ router.get('/all/:pattern', function (req, res, next) {
 router.get('/all/email/:email', function (req, res, next) {
   let email = req.params.email;
 
-  db.users.find({ email }, function (err, users) {
-    if (err) {
-      res.send(err);
-    } else {
-      res.json(users);
+  db.users.find(
+    { email: { $regex: email, $options: 'i' } },
+    function (err, users) {
+      if (err) {
+        res.send(err);
+      } else {
+        res.json(users);
+      }
     }
-  });
+  );
 });
 
 router.get('/in/:query', function (req, res, next) {


### PR DESCRIPTION
### Issue
Fixes #792 

### Description
The backend code for searching for users by email was case sensitive leading to deduplication errors, as per issue description. Making it case insensitive here! The method used we're bypassing the index, which isn't great, but hopefully shouldn't lead to problems with the amounts of data we've got.