### PR TITLE
Fix links not opening for Standard users

### DIFF
--- a/apps/maptio/src/app/shared/components/textarea/textarea.component.html
+++ b/apps/maptio/src/app/shared/components/textarea/textarea.component.html
@@ -61,7 +61,7 @@
 
   <div
     *ngIf="!isEditMode && !isTextEmpty"
-    (click)="!isUnauthorized && (isEditMode = true)"
+    (click)="onClick($event)"
     class="position-relative w-100 bg-light p-2 rounded"
   >
     <markdown

--- a/apps/maptio/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/maptio/src/app/shared/components/textarea/textarea.component.ts
@@ -47,4 +47,14 @@ export class CommonTextareaComponent implements OnInit {
     this.save.emit(text);
     this.cd.markForCheck();
   }
+
+  onClick(event: Event) {
+    const eventTarget = event.target as HTMLElement;
+    const isLink = eventTarget.nodeName === 'A';
+
+    if (!isLink && !this.isUnauthorized) {
+      this.isEditMode = true;
+      this.cd.markForCheck();
+    }
+  }
 }


### PR DESCRIPTION
### Issue
Fixes #814 

### Description
Standard users couldn't click links in description. This was due to a quick and dirty click handler used for opening editing of a field.

### Setup
Prepare a standard user.
Add a link to a circle.

### Testing
* Log in as a standard user and make sure that you can click on a link in a circle description.
* Make sure that you can still do the same as an admin.
* Make sure that clicking on the link (when you're an admin) doesn't trigger editing anymore...
* ...but that editing is still triggered when you click anywhere outside of a link!
