### PR TITLE
Improve searching through roles

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/searching/search.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/searching/search.component.ts
@@ -68,9 +68,8 @@ export class SearchComponent implements OnInit {
 
       const roles = initiative
         .getAllParticipants()
-        .map((participant) =>
-          participant.roles?.[0]?.description?.toLowerCase()
-        )
+        .flatMap((participant) => participant.roles ?? [])
+        .map((role) => `${role.title} ${role.description}`.toLowerCase())
         .join('');
       const rolesMatch = roles?.includes(searchTerm);
 


### PR DESCRIPTION
### Issue
This is in response to a customer request: https://app.intercom.com/a/inbox/q3x5lnhp/inbox/shared/all/conversation/106323200011155?view=List (internal)

### Description
At the moment, when searching for initiatives, we match the search term only with the description of the first role of each person, ignoring all role titles and all the other roles. This is a bit broken. This PR includes all roles - and their titles - in the search. It also refactors the search code a bit to make the changes then a lot simpler.

### Setup
Add multiple roles to one person. Add unique words in the description of the roles.

### Testing
Make sure that the initiative can be found by unique words in either the role titles or descriptions.
