### PR TITLE
Fix localisation errors in local development

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -19,7 +19,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "localize": ["en-US", "de", "fr", "ja", "pl"],
+            "localize": false,
             "outputPath": "dist/apps/maptio",
             "index": "apps/maptio/src/index.html",
             "main": "apps/maptio/src/main.ts",
@@ -65,6 +65,7 @@
                   "with": "apps/maptio/src/environments/environment.staging.ts"
                 }
               ],
+              "localize": ["en-US", "de", "es", "fr", "ja", "nl", "pl", "pt"],
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
@@ -92,6 +93,7 @@
                   "with": "apps/maptio/src/environments/environment.prod.ts"
                 }
               ],
+              "localize": ["en-US", "de", "fr", "ja", "pl"],
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
@@ -111,6 +113,12 @@
                   "maximumError": "10kb"
                 }
               ]
+            },
+            "en-US": {
+              "localize": ["en-US"]
+            },
+            "de": {
+              "localize": ["de"]
             }
           },
           "defaultConfiguration": ""
@@ -124,6 +132,12 @@
           "configurations": {
             "production": {
               "browserTarget": "maptio:build:production"
+            },
+            "en-US": {
+              "browserTarget": "maptio:build:en-US"
+            },
+            "de": {
+              "browserTarget": "maptio:build:de"
             }
           }
         },


### PR DESCRIPTION
This is a small follow-up to the i18n work. It fixes up `build` and `serve` configurations so that serving the project in development by default just runs without localisation (rather than with an array of languages, causing errors!). I used to just manually switch the array to `false` locally but that was obviously absurd and so finally this is a fix to set up the configurations properly.
