### PR TITLE
Fix incorrect call to method in catchError

### DIFF
--- a/apps/maptio/src/app/shared/services/user/user.service.ts
+++ b/apps/maptio/src/app/shared/services/user/user.service.ts
@@ -87,7 +87,7 @@ export class UserService implements OnDestroy {
       }
     }),
 
-    catchError(this.handleLoginError),
+    catchError((error) => this.handleLoginError(error)),
 
     // Cache the user
     shareReplay(1)


### PR DESCRIPTION
See error here: https://github.com/Maptio/maptio/issues/811#issuecomment-1708528632

Turns code I wrote to catch login errors was incorrect! The method `this.handleLoginError` was not receiving the correct `this`! Now fixed.