### PR TITLE
Switch change detection strategy

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -1,4 +1,3 @@
-import {} from '@angular/core';
 import {
   Component,
   Input,
@@ -9,7 +8,6 @@ import {
   signal,
   ViewChild,
   ChangeDetectorRef,
-  ChangeDetectionStrategy,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NgIf } from '@angular/common';
@@ -61,7 +59,6 @@ import { EditTagsComponent } from '../tags/edit-tags.component';
   selector: 'building',
   templateUrl: './building.component.html',
   styleUrls: ['./building.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
     OnboardingMessageComponent,


### PR DESCRIPTION
In one of the last commits of #843 , I removed the old outliner. Turns out that code was triggering change detection and without it the link between the new outliner and the map broke. Ha. This PR simply change the change detection strategy as OnPush really isn't needed here - and we'll get the benefits when we fully move to signals anyway!
