### PR TITLE
Scroll outliner to selected initiative

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.html
@@ -4,7 +4,7 @@
     [paddingTop]="'15px'"
     i18n
   >
-    Edit your circle structure here. Try clicking Expand All.
+    Edit your circle structure here.
   </maptio-onboarding-message>
 
   <ul ngbNav #nav="ngbNav" class="nav-pills nav-fill">

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -584,7 +584,7 @@ export class BuildingComponent implements OnDestroy {
     for (let i = 0; i < depth; i++) {
       setTimeout(() => {
         this.scrollInitiativeIntoView(id);
-      }, i * 100);
+      }, i * 20);
     }
   }
 

--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -8,6 +8,7 @@ import {
   signal,
   ViewChild,
   ChangeDetectorRef,
+  effect,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { NgIf } from '@angular/common';
@@ -158,6 +159,10 @@ export class BuildingComponent implements OnDestroy {
         this.onLibraryRoleDelete(deletedRole);
       }
     );
+
+    effect(() => {
+      this.scrollInitiativeIntoView(this.selectedInitiativeId());
+    });
   }
 
   ngOnDestroy() {
@@ -540,5 +545,20 @@ export class BuildingComponent implements OnDestroy {
     // TreeControl class for directly controlling expansion
     this.expandInitiativeId.set(null);
     this.expandInitiativeId.set(id);
+  }
+
+  scrollInitiativeIntoView(initiativeId: number) {
+    // Not the Angular way, but worked well in another project, so I'm using
+    // this tested method again
+    const nativeElement = window.document.getElementById(
+      'outline-item-' + initiativeId.toString()
+    );
+
+    if (!nativeElement) return;
+
+    (nativeElement as any).scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@ngrx/router-store": "~16.0.0",
         "@ngrx/store": "16.0.1",
         "@ngrx/store-devtools": "16.0.1",
-        "@notebits/outline": "^0.0.40",
+        "@notebits/outline": "^0.0.41",
         "@nx/angular": "17.0.2",
         "@openreplay/tracker": "^3.5.12",
         "@popperjs/core": "^2.11.6",
@@ -7229,9 +7229,9 @@
       }
     },
     "node_modules/@notebits/outline": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.40.tgz",
-      "integrity": "sha512-tjkDEzYvSz4+A5KxBSfPkIrNsj0E+udQPhHJE/fB8zkd/FChamTwAwrqz7lCyz/Mh3cMmnUENrg2aTpGnrLugw==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.41.tgz",
+      "integrity": "sha512-QbUnqbv8aWSf7lKb9iGPxAdWWZk2WAK+clWf1eT6YcmyHt/y4vupCjHqqWkpJX+QOFDONMFdcKMf8c78yyfF8Q==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -39431,9 +39431,9 @@
       }
     },
     "@notebits/outline": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.40.tgz",
-      "integrity": "sha512-tjkDEzYvSz4+A5KxBSfPkIrNsj0E+udQPhHJE/fB8zkd/FChamTwAwrqz7lCyz/Mh3cMmnUENrg2aTpGnrLugw==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.41.tgz",
+      "integrity": "sha512-QbUnqbv8aWSf7lKb9iGPxAdWWZk2WAK+clWf1eT6YcmyHt/y4vupCjHqqWkpJX+QOFDONMFdcKMf8c78yyfF8Q==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@ngrx/router-store": "~16.0.0",
         "@ngrx/store": "16.0.1",
         "@ngrx/store-devtools": "16.0.1",
-        "@notebits/outline": "^0.0.38",
+        "@notebits/outline": "^0.0.39",
         "@nx/angular": "17.0.2",
         "@openreplay/tracker": "^3.5.12",
         "@popperjs/core": "^2.11.6",
@@ -7229,9 +7229,9 @@
       }
     },
     "node_modules/@notebits/outline": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.38.tgz",
-      "integrity": "sha512-zU3pHkDTy8EBrnouJm/04MdT4IHVSEwAvoXiWOOBvgx73IXlz3uu4KmyF/SJDSAJY/WelMEdaq2YH/71lIa5UQ==",
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.39.tgz",
+      "integrity": "sha512-62Bfk3tG2m2co3intGyPk3hdWbL3up5MnKbDVxNIkD59MGNVCmQiA2N+zYE7JDSEBT+xRmRLd2uJg91CWQ+W2Q==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -39431,9 +39431,9 @@
       }
     },
     "@notebits/outline": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.38.tgz",
-      "integrity": "sha512-zU3pHkDTy8EBrnouJm/04MdT4IHVSEwAvoXiWOOBvgx73IXlz3uu4KmyF/SJDSAJY/WelMEdaq2YH/71lIa5UQ==",
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.39.tgz",
+      "integrity": "sha512-62Bfk3tG2m2co3intGyPk3hdWbL3up5MnKbDVxNIkD59MGNVCmQiA2N+zYE7JDSEBT+xRmRLd2uJg91CWQ+W2Q==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@ngrx/router-store": "~16.0.0",
         "@ngrx/store": "16.0.1",
         "@ngrx/store-devtools": "16.0.1",
-        "@notebits/outline": "^0.0.39",
+        "@notebits/outline": "^0.0.40",
         "@nx/angular": "17.0.2",
         "@openreplay/tracker": "^3.5.12",
         "@popperjs/core": "^2.11.6",
@@ -7229,9 +7229,9 @@
       }
     },
     "node_modules/@notebits/outline": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.39.tgz",
-      "integrity": "sha512-62Bfk3tG2m2co3intGyPk3hdWbL3up5MnKbDVxNIkD59MGNVCmQiA2N+zYE7JDSEBT+xRmRLd2uJg91CWQ+W2Q==",
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.40.tgz",
+      "integrity": "sha512-tjkDEzYvSz4+A5KxBSfPkIrNsj0E+udQPhHJE/fB8zkd/FChamTwAwrqz7lCyz/Mh3cMmnUENrg2aTpGnrLugw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -39431,9 +39431,9 @@
       }
     },
     "@notebits/outline": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.39.tgz",
-      "integrity": "sha512-62Bfk3tG2m2co3intGyPk3hdWbL3up5MnKbDVxNIkD59MGNVCmQiA2N+zYE7JDSEBT+xRmRLd2uJg91CWQ+W2Q==",
+      "version": "0.0.40",
+      "resolved": "https://registry.npmjs.org/@notebits/outline/-/outline-0.0.40.tgz",
+      "integrity": "sha512-tjkDEzYvSz4+A5KxBSfPkIrNsj0E+udQPhHJE/fB8zkd/FChamTwAwrqz7lCyz/Mh3cMmnUENrg2aTpGnrLugw==",
       "requires": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@ngrx/router-store": "~16.0.0",
     "@ngrx/store": "16.0.1",
     "@ngrx/store-devtools": "16.0.1",
-    "@notebits/outline": "^0.0.38",
+    "@notebits/outline": "^0.0.39",
     "@nx/angular": "17.0.2",
     "@openreplay/tracker": "^3.5.12",
     "@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@ngrx/router-store": "~16.0.0",
     "@ngrx/store": "16.0.1",
     "@ngrx/store-devtools": "16.0.1",
-    "@notebits/outline": "^0.0.40",
+    "@notebits/outline": "^0.0.41",
     "@nx/angular": "17.0.2",
     "@openreplay/tracker": "^3.5.12",
     "@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@ngrx/router-store": "~16.0.0",
     "@ngrx/store": "16.0.1",
     "@ngrx/store-devtools": "16.0.1",
-    "@notebits/outline": "^0.0.39",
+    "@notebits/outline": "^0.0.40",
     "@nx/angular": "17.0.2",
     "@openreplay/tracker": "^3.5.12",
     "@popperjs/core": "^2.11.6",


### PR DESCRIPTION
### Issue
Addresses this task:
> [REGRESSION] [SMALL] While connecting the new outliner with the expanded map, I appear to have accidentally broken a part of the flow of opening and closing circles. Specifically, when you're zoomed in a few levels deep and click outside the currently selected circle, you should be zoomed out and see all the siblings of that circle (see behaviour in production). Instead, now (see behaviour on staging), you're zoomed out to the cover of the parent circle, making exploration a lot more annoying!
from #846 

That in turn comes from this Slack thread: https://maptio.slack.com/archives/C01QCQJMS23/p1698827400233449

Also tweaks translation for onboarding message to avoid referring to a button we've just removed.

### Description
See description above.