### PR TITLE
Fix circle cover appearing on first rather than second click out of circle

### DIFF
--- a/apps/maptio/src/app/modules/circle-map/circle-map.service.ts
+++ b/apps/maptio/src/app/modules/circle-map/circle-map.service.ts
@@ -141,6 +141,11 @@ export class CircleMapService {
   }
 
   onSelectedIdChange(selectedId: number) {
+    // If the selected circle, there is no need to react to the input change
+    if (selectedId === this.selectedCircle.value?.data.id) {
+      return;
+    }
+
     const circle = this.getCircleByInitiativeId(selectedId);
 
     if (circle) {


### PR DESCRIPTION
### Issue
Addresses this task:
> [REGRESSION] [SMALL] While connecting the new outliner with the expanded map, I appear to have accidentally broken a part of the flow of opening and closing circles. Specifically, when you're zoomed in a few levels deep and click outside the currently selected circle, you should be zoomed out and see all the siblings of that circle (see behaviour in production). Instead, now (see behaviour on staging), you're zoomed out to the cover of the parent circle, making exploration a lot more annoying!

from #846 