### PR TITLE
Fix new initiative not being selected

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -431,8 +431,6 @@ export class BuildingComponent implements OnDestroy {
 
   private transformNodesIntoOutlineData(nodes): NotebitsOutlineData {
     return nodes.map((node) => {
-      console.log('children', node.children);
-
       const children =
         node.children && node.children.length > 0
           ? this.transformNodesIntoOutlineData(node.children)
@@ -488,8 +486,12 @@ export class BuildingComponent implements OnDestroy {
 
     this.sendInitiativesToOutliner();
     this.expandInitiative(parentId);
-    this.workspaceFacade.setSelectedInitiativeID(newInitiative.id);
+
+    // This will also update the data for the map and the details panel...
     this.saveChanges();
+
+    // ...so that we can then select the new initiative there!
+    this.workspaceFacade.setSelectedInitiativeID(newInitiative.id);
   }
 
   onInitiativeMove(event: OutlineItemMoveEvent) {


### PR DESCRIPTION
### Issue
Fixes the following issue from #846 :
>  [USABILITY] When a new sub-circle is added, it's (no longer?) showing on the map and in the circle details pane, let's change that


### Description
This turned out to be waaaaaay gnarlier than I anticipated. The NgRx part of the code was working correctly - when a new circle was added, the ID of the selected circle was changed. However, at that stage, the map and the details panel got the newly selected ID... but they still had the old data. So much for partial, incremental changes to state management. This was happening because we only updated the data _after_ saving it to the database - and only if that was successful. I changed the saving code to perform a crude version of optimistic updates... and if the save fails, we now show an alert. Not great. Let's do more testing as this is actually a hugely significant change. Probably a good one... especially as we never showed the saving errors even when they did occur, not great.