### PR TITLE
Scroll form and errors into view as needed

### DIFF
--- a/apps/maptio/src/app/modules/team/components/member-details/member-single.component.html
+++ b/apps/maptio/src/app/modules/team/components/member-details/member-single.component.html
@@ -11,10 +11,7 @@
       *permissionsOnly="Permissions.canEditUser"
       class="d-none d-md-flex align-items-center col-1 px-0 justify-content-between"
     >
-      <button
-        class="btn bg-transparent"
-        (click)="isEditToggled = !isEditToggled"
-      >
+      <button class="btn bg-transparent" (click)="onToggle()">
         <i
           [class.fa-caret-right]="!isEditToggled"
           [class.fa-caret-down]="isEditToggled"
@@ -228,87 +225,4 @@
   {{ errorMessage }}
 </div>
 
-<!-- TODO: Extract the two additional non-form fields from here too -->
-<!-- <div class="bg-light py-2" *ngIf="isEditToggled">
-  <form
-    [formGroup]="editUserForm"
-    (submit)="updateUser()"
-    class="offset-1 col-5"
-  >
-    <div class="form-group form-inline row" *ngIf="member.isActivationPending">
-      <label
-        class="col-4 d-flex justify-content-start text-gray-light text-uppercase small"
-        for="inputFirstname"
-        >First name</label
-      >
-      <input
-        type="text"
-        class="col-8 form-control form-control-warning"
-        formControlName="firstname"
-      />
-    </div>
-    <div class="form-group form-inline row" *ngIf="member.isActivationPending">
-      <label
-        class="col-4 d-flex justify-content-start text-gray-light text-uppercase small"
-        for="inputLastname"
-        >Last name</label
-      >
-      <input
-        type="text"
-        class="col-8 form-control form-control-warning"
-        formControlName="lastname"
-      />
-    </div>
-    <div
-      class="form-group form-inline row"
-      *ngIf="this.member.isActivationPending && !this.member.isInvitationSent"
-    >
-      <label
-        class="col-4 d-flex justify-content-start text-gray-light text-uppercase small"
-        for="inputEmail"
-        >Email</label
-      >
-      <input
-        type="text"
-        class="col-8 form-control form-control-warning"
-        formControlName="email"
-      />
-    </div>
-    <div class="form-group form-inline row text-muted">
-      <label
-        class="col-4 d-flex justify-content-start text-gray-light text-uppercase small"
-        for="inputLastSeen"
-        >Created</label
-      >
-      <span class="col-8">{{ getAgo(member.createdAt) }} ago</span>
-    </div>
-    <div class="form-group form-inline row text-muted">
-      <label
-        class="col-4 d-flex justify-content-start text-gray-light text-uppercase small"
-        for="inputLastSeen"
-        >Last log in</label
-      >
-      <span class="col-8">{{ getAgo(member.lastSeenAt) }} ago</span>
-    </div>
-    <div
-      class="form-group form-inline row d-flex justify-content-end"
-      *ngIf="member.isActivationPending"
-    >
-      <span class="text-green mx-1" *ngIf="isSaving">
-        <i class="fas fa-circle-notch fa-spin"></i>
-      </span>
-      <span
-        class="text-green mx-1 flash small"
-        *ngIf="isSavingSuccess"
-        [class.show]="isSavingSuccess"
-      >
-        <i class="fas fa-save"></i>Successfully saved!
-      </span>
-      <span class="text-danger mx-1 small" *ngIf="savingFailedMessage">{{
-        savingFailedMessage
-      }}</span>
-
-      <button type="submit" class="btn btn-success">Save</button>
-    </div>
-  </form>
-</div> -->
+<span [id]="'endOfComponent-' + member.shortid"></span>

--- a/apps/maptio/src/app/modules/team/components/member-details/member-single.component.ts
+++ b/apps/maptio/src/app/modules/team/components/member-details/member-single.component.ts
@@ -108,6 +108,7 @@ export class MemberSingleComponent implements OnChanges {
     if (!this.member.email) {
       this.errorMessage =
         'Please enter an email address to send the invitation to.';
+      this.scrollFullComponentIntoView(false);
       this.cd.markForCheck();
       return;
     }
@@ -155,6 +156,8 @@ export class MemberSingleComponent implements OnChanges {
           `;
         }
 
+        this.scrollFullComponentIntoView();
+
         this.isDisplaySendingLoader = false;
         this.cd.markForCheck();
       });
@@ -165,6 +168,16 @@ export class MemberSingleComponent implements OnChanges {
     this.duplicateUsers = duplicateUsers;
   }
 
+  onToggle() {
+    this.isEditToggled = !this.isEditToggled;
+    this.cd.markForCheck();
+
+    // Scroll to the bottom of the component but avoid using fallback in
+    // firefox as it's not as important here and causes too much unnecessary
+    // scrolling
+    this.scrollFullComponentIntoView(false);
+  }
+
   onEditMember() {
     this.onCancelEditing();
   }
@@ -172,6 +185,28 @@ export class MemberSingleComponent implements OnChanges {
   onCancelEditing() {
     this.isEditToggled = false;
     this.cd.markForCheck();
+  }
+
+  private scrollFullComponentIntoView(fallback = true) {
+    setTimeout(() => {
+      // Not the Angular way, but worked well in another project, so I'm using
+      // this tested method again
+      const elementId = `endOfComponent-${this.member.shortid}`;
+      const nativeElement = window.document.getElementById(elementId);
+
+      if (!nativeElement) return;
+
+      this.scrollToElement(nativeElement, fallback);
+    }, 100);
+  }
+
+  private scrollToElement(element: any, fallback: boolean) {
+    // Ideally use the better method, not always available
+    if (element.scrollIntoViewIfNeeded) {
+      element.scrollIntoViewIfNeeded(false);
+    } else if (fallback) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
   }
 
   // TODO: Copy over to MemberForm component (and fix "Never ago"!!!)


### PR DESCRIPTION
### Issue
Fixes #859 

### Description
Apart from what's already described in the issue, this also adds the scrolling in several other situations:
* when any of the several other possible errors occur on invitation,
* when the form is toggled on, so a small but nice little usability tweak.

The implementation proved much trickier than I'd hoped - ended up using `scrollIntoViewIfNeeded` (and a fallback for firefox), an additional element to get the behaviour to feel natural and work for errors too - this was not pleasant and so the code is not neat as I don't think it's that important and I already spent longer than I'd hoped on this.