### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.4.0
+FROM node:16.14.0
 
 WORKDIR /app
 


### PR DESCRIPTION
Update nodejs-version to avoid `npm WARN EBADENGINE Unsupported engine`

### Description
When installing using Dockerfile, it shows a lot of warning due to an old version of NodeJS:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'maptio@2.0.0',
npm WARN EBADENGINE   required: { node: '16.14.0', npm: '8.3.1' },
npm WARN EBADENGINE   current: { node: 'v16.4.0', npm: '7.18.1' }
npm WARN EBADENGINE }
...
```
This always needs to be in line with https://github.com/Maptio/maptio/blob/94243800ca09f2f18ac881c77663d3c0c33198de/package.json#L6 (!!!)

### Testing
Run `docker-compose up -d --build` again, and then it builds.