### PR TITLE
Adjust wording of first three pricing suggestions

### DIFF
--- a/apps/maptio/src/app/modules/payment/pricing-info/pricing-info.component.html
+++ b/apps/maptio/src/app/modules/payment/pricing-info/pricing-info.component.html
@@ -58,7 +58,7 @@
   <h1 class="mt-5">Finding the price you'd love to pay</h1>
 
   <p>
-    We love it when customers contribute $50 - $150 per month, depending on the
+    We love it when customers contribute $50 - $200 per month, depending on the
     value they get from Maptio and their financial means. This helps us build a
     sustainable operation, care for our livelihoods, and fuel the creative
     energy we put into it.

--- a/apps/maptio/src/app/modules/payment/pricing-selection/pricing-selection.component.html
+++ b/apps/maptio/src/app/modules/payment/pricing-selection/pricing-selection.component.html
@@ -19,9 +19,9 @@
       <div ngbAccordionCollapse>
         <div ngbAccordionBody>
           <ng-template>
-            We suggest $70 - $150 per month. Adjust upward or downward depending
-            on your team size, and to find your sweetspot of affordability,
-            value, and contribution.
+            We suggest $100 - $200 per month. Adjust upward or downward
+            depending on your team size, and to find your sweet spot of
+            affordability, value, and contribution.
           </ng-template>
         </div>
       </div>
@@ -37,8 +37,8 @@
       <div ngbAccordionCollapse>
         <div ngbAccordionBody>
           <ng-template>
-            We suggest $20 - $60 per month. Adjust upward or downward depending
-            on your team size, and to find your sweetspot of affordability,
+            We suggest $40 - $80 per month. Adjust upward or downward depending
+            on your team size, and to find your sweet spot of affordability,
             value, and contribution.
           </ng-template>
         </div>
@@ -56,7 +56,7 @@
       <div ngbAccordionCollapse>
         <div ngbAccordionBody>
           <ng-template>
-            We suggest $10 or $20 per month. If you attract revenue or funding
+            How about $20 or $30 per month? If you attract revenue or funding
             later you can increase this any time.
           </ng-template>
         </div>


### PR DESCRIPTION
Just a quick change of wording on the pricing page, as discussed here: https://maptio.slack.com/archives/C01QCQJMS23/p1718613462420339
