### PR TITLE
Change context menu icon to improve discoverability

### DIFF
--- a/apps/maptio/src/index.html
+++ b/apps/maptio/src/index.html
@@ -44,8 +44,8 @@
       rel="stylesheet"
     /> -->
     <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@48,300,0,0"
     />
   </head>
 

--- a/apps/maptio/src/styles/notebits/_notebits.scss
+++ b/apps/maptio/src/styles/notebits/_notebits.scss
@@ -1,3 +1,13 @@
+// Duplicate the hover behaviour of the buttons in the side panel, this should
+// eventually be fixed in the notebits side panel component itself
+.side-panel__toggle {
+  opacity: 0.5;
+}
+
+.side-panel__toggle:hover {
+  opacity: 1;
+}
+
 @include media-breakpoint-down(md) {
   .side-panel {
     display: none !important;


### PR DESCRIPTION
### Issue
Fixes #880

### Description
When I created the outliner, I used the then fairly new (IIRC) Material Symbols icons library. For some reason (I don't think this was intentional, I imagine I was in a hurry and didn't pay enough attention), I included the library with a link that specified the lowest possible weight. I didn't notice that I wasn't using the default icon font weight and just thought that the latest icons were more slender, duh! This corrects my mistake.

This also changes the look of the side panel icons... Not sure I like that change... and so I was moved to implement the same kind of hover opacity effects as we have in the outliner.