### PR TITLE
Add title cover to onboarding video

### DIFF
--- a/apps/maptio/src/app/core/header/header.component.html
+++ b/apps/maptio/src/app/core/header/header.component.html
@@ -12,7 +12,7 @@
 <nav
   class="d-flex header navbar navbar-expand-md navbar-light bg-transparent justify-content-between align-items-baseline px-3"
   [class.grayscale]="loaderService.isLoading"
-  >
+>
   <a routerLink="home" class="no-underline navbar-brand">
     <img
       width="32"
@@ -21,7 +21,7 @@
       src="assets/images/logo.png"
       alt="Home"
       i18n-alt
-      />
+    />
   </a>
 
   <button
@@ -33,7 +33,7 @@
     aria-label="Toggle navigation"
     i18n-aria-label
     (click)="isMenuOpened = !isMenuOpened"
-    >
+  >
     <i
       class="fas"
       [class.fa-bars]="!isMenuOpened"
@@ -47,26 +47,24 @@
     class="navbar-collapse"
     [ngClass]="{ ' p-2 vh-100 vw-100': isMenuOpened }"
     id="navbarSupportedContent"
-    >
+  >
     <ul
       class="navbar-nav d-flex justify-content-end w-100"
       (click)="onMenuClick()"
-      >
+    >
       <li class="nav-item d-none d-md-flex align-items-center">
         <a
           class="nav-link"
           target="blank"
           href="{{ KB_URL_HOME }}"
           i18n="@@help"
-          >
+        >
           Help
         </a>
       </li>
 
       @if (team?.isPaying === false) {
-        <li
-          class="nav-item d-none d-md-flex align-items-center"
-          >
+        <li class="nav-item d-none d-md-flex align-items-center">
           <a class="nav-link" target="blank" routerLink="/pricing">
             <ng-container i18n="@@pricing">Pricing</ng-container>
           </a>
@@ -79,9 +77,9 @@
             class="nav-link"
             routerLink="/teams/{{ team?.team_id }}/{{ team?.getSlug() }}"
             i18n
-            >
-          Settings
-        </a>
+          >
+            Settings
+          </a>
         </li>
       }
 
@@ -89,31 +87,31 @@
         (userService.isAuthenticated$ | async) &&
         datasets &&
         datasets?.length !== 0
-        ) {
+      ) {
         <li
           ngbDropdown
           class="nav-item dropdown d-none d-md-flex align-items-center"
-          >
+        >
           <a
             class="nav-link dropdown-toggle"
             id="mapsListDropdownLink"
             ngbDropdownToggle
-            >
+          >
             <ng-conatiner i18n>Maps</ng-conatiner>
           </a>
           <div
             class="dropdown-menu dropdown-menu-end overflow"
             ngbDropdownMenu
             aria-labelledby="mapsListDropdownLink"
-            >
+          >
             @for (dataset of datasets; track dataset) {
               @if (dataset.initiative) {
                 <a
                   ngbDropdownItem
-                routerLink="/map/{{ dataset.datasetId }}/{{
-                  dataset.initiative.getSlug()
-                }}"
-                  >
+                  routerLink="/map/{{ dataset.datasetId }}/{{
+                    dataset.initiative.getSlug()
+                  }}"
+                >
                   {{ dataset?.initiative.name }}
                 </a>
               }
@@ -125,36 +123,32 @@
       <maptio-language-picker class="d-none d-md-flex"></maptio-language-picker>
 
       @if (userService.isAuthenticated$ | async) {
-        <li
-          ngbDropdown
-          class="nav-item dropdown ms-3"
-          id="profileInformation"
-          >
+        <li ngbDropdown class="nav-item dropdown ms-3" id="profileInformation">
           <a
             class="nav-link dropdown-toggle without-caret px-0 d-none d-md-block"
             id="profileDropdownLink"
             ngbDropdownToggle
-            >
+          >
             <div>
               <img
                 src="{{ user?.picture }}"
                 class="avatar my-1"
                 alt="{{ user?.name }}"
-                />
+              />
             </div>
           </a>
           <div
             ngbDropdownMenu
             class="dropdown-menu dropdown-menu-end"
             aria-labelledby="profileDropdownLink"
-            >
+          >
             <a
               ngbDropdownItem
               class="dropdown-item py-2"
-            routerLink="profile/{{ user?.shortid }}/{{
-              user?.getSlug() || 'profile'
-            }}"
-              >
+              routerLink="profile/{{ user?.shortid }}/{{
+                user?.getSlug() || 'profile'
+              }}"
+            >
               <ng-container i18n>Profile</ng-container>
             </a>
             @if (teams?.length > 0) {
@@ -162,31 +156,33 @@
             }
             @if (teams?.length > 0) {
               <h6 class="dropdown-header ps-3">
-                <ng-container i18n="@@organisations">Organisations</ng-container>
+                <ng-container i18n="@@organisations">
+                  Organisations
+                </ng-container>
               </h6>
             }
             @if (teams?.length > 1) {
-              @for (team of teams | slice : 1 : 5; track team) {
+              @for (team of teams | slice: 1 : 5; track team) {
                 <a
                   ngbDropdownItem
                   class="dropdown-item"
                   routerLink="/teams/{{ team.team_id }}/{{ team?.getSlug() }}"
-                  >
+                >
                   {{ team?.name }}
                 </a>
               }
               <a ngbDropdownItem class="dropdown-item" routerLink="/teams" i18n>
-              More ...
-            </a>
+                More ...
+              </a>
             }
             @if (teams?.length === 1) {
               <a
                 ngbDropdownItem
                 class="dropdown-item"
-            routerLink="/teams/{{ teams[0]?.team_id }}/{{
-              teams[0]?.getSlug()
-            }}"
-                >
+                routerLink="/teams/{{ teams[0]?.team_id }}/{{
+                  teams[0]?.getSlug()
+                }}"
+              >
                 {{ teams[0]?.name }}
               </a>
             }
@@ -197,17 +193,15 @@
               id="logoutButton"
               routerLink="/logout"
               i18n
-              >
-            Log out
-          </a>
+            >
+              Log out
+            </a>
           </div>
         </li>
       }
 
       @if ((userService.isAuthenticated$ | async) === false && !isSignUp()) {
-        <li
-          class="nav-item d-flex align-items-center ps-2"
-          >
+        <li class="nav-item d-flex align-items-center ps-2">
           <a maptioLoginRedirect class="btn btn-link px-0" i18n>Log in</a>
         </li>
       }
@@ -220,7 +214,7 @@
           routerLink="profile/{{ user?.shortid }}/{{
             user?.getSlug() || 'profile'
           }}"
-          >
+        >
           <ng-container i18n>Profile</ng-container>
         </a>
       </li>
@@ -228,23 +222,23 @@
       @if (datasets?.length > 0) {
         <li class="d-md-none dropdown-divider"></li>
         <li class="d-md-none dropdown-header px-0 text-uppercase" i18n>Maps</li>
-        @for (dataset of datasets | slice : 0 : 2; track dataset) {
-          <li
-            class="nav-item d-md-none"
-            >
+        @for (dataset of datasets | slice: 0 : 2; track dataset) {
+          <li class="nav-item d-md-none">
             <a
               class="btn btn-link px-0"
-            routerLink="/map/{{ dataset.datasetId }}/{{
-              dataset.initiative.getSlug()
-            }}"
-              >
+              routerLink="/map/{{ dataset.datasetId }}/{{
+                dataset.initiative.getSlug()
+              }}"
+            >
               {{ dataset?.initiative.name }}
             </a>
           </li>
         }
         @if (datasets?.length > 3) {
           <li class="nav-item d-md-none">
-            <a class="btn btn-link px-0" routerLink="/home" i18n>All maps ...</a>
+            <a class="btn btn-link px-0" routerLink="/home" i18n>
+              All maps ...
+            </a>
           </li>
         }
       }
@@ -254,14 +248,12 @@
         <li class="d-md-none dropdown-header px-0 text-uppercase" i18n>
           Organizations
         </li>
-        @for (team of teams | slice : 0 : 2; track team) {
-          <li
-            class="nav-item d-md-none"
-            >
+        @for (team of teams | slice: 0 : 2; track team) {
+          <li class="nav-item d-md-none">
             <a
               class="btn btn-link px-0"
               routerLink="/teams/{{ team.team_id }}/{{ team.getSlug() }}"
-              >
+            >
               {{ team.name }}
             </a>
           </li>
@@ -269,13 +261,9 @@
         @if (teams?.length > 3) {
           <li class="nav-item d-md-none">
             @if (teams?.length > 1) {
-              <a
-                class="btn btn-link px-0"
-                routerLink="/teams"
-                i18n
-                >
-            All organizations...
-          </a>
+              <a class="btn btn-link px-0" routerLink="/teams" i18n>
+                All organizations...
+              </a>
             }
           </li>
         }
@@ -303,7 +291,7 @@
           href="{{ KB_URL_HOME }}"
           target="blank"
           i18n="@@help"
-          >
+        >
           Help
         </a>
       </li>
@@ -325,7 +313,7 @@
             id="logoutButton"
             routerLink="/logout"
             i18n
-            >
+          >
             Log out
           </a>
         </li>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -8,7 +8,7 @@
     [ngbTooltip]="freeTrialCutoffDateMessage"
     container="body"
     placement="bottom"
-    >
+  >
     {{ remainingTrialTimeMessage }}
   </div>
 
@@ -16,7 +16,7 @@
     class="btn btn-info text-white"
     [href]="REQUEST_TRIAL_EXTENSION_EMAIL"
     target="_blank"
-    >
+  >
     <span class="onboarding-banner__emoji">⏳</span>
     <ng-container>&nbsp;</ng-container>
     <ng-container i18n>Request more time</ng-container>
@@ -42,7 +42,7 @@
     class="btn btn-success text-white"
     [href]="BOOK_ONBOARDING_URL"
     target="_blank"
-    >
+  >
     <span class="onboarding-banner__emoji">💬</span>
     <ng-container>&nbsp;</ng-container>
     <ng-container i18n>Book free Zoom help call</ng-container>

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.html
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.html
@@ -28,6 +28,16 @@
     <ng-container i18n>Subscribe now</ng-container>
   </a>
 
+  <button class="btn btn-info text-white" (click)="toggleOnboardingVideo()">
+    <span class="onboarding-banner__emoji">▶️</span>
+    <ng-container>&nbsp;</ng-container>
+    @if (isOnboardingVideoVisible()) {
+      <ng-container i18n>Hide welcome video</ng-container>
+    } @else {
+      <ng-container i18n>Show welcome video</ng-container>
+    }
+  </button>
+
   <a
     class="btn btn-success text-white"
     [href]="BOOK_ONBOARDING_URL"

--- a/apps/maptio/src/app/core/header/onboarding-banner.component.ts
+++ b/apps/maptio/src/app/core/header/onboarding-banner.component.ts
@@ -1,19 +1,22 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 
 import { environment } from '@maptio-environment';
 import { Team } from '@maptio-shared/model/team.data';
 import { User } from '@maptio-shared/model/user.data';
 import { RouterLink } from '@angular/router';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-
+import { WorkspaceService } from '../../workspace/workspace.service';
 
 @Component({
-    selector: 'maptio-onboarding-banner',
-    templateUrl: './onboarding-banner.component.html',
-    styleUrls: ['./onboarding-banner.component.scss'],
-    imports: [NgbTooltipModule, RouterLink]
+  selector: 'maptio-onboarding-banner',
+  templateUrl: './onboarding-banner.component.html',
+  styleUrls: ['./onboarding-banner.component.scss'],
+  imports: [NgbTooltipModule, RouterLink],
 })
 export class OnboardingBannerComponent {
+  workspaceService = inject(WorkspaceService);
+  isOnboardingVideoVisible = this.workspaceService.isOnboardingVideoVisible;
+
   @Input() set user(user: User) {
     if (user?.teams?.length > 1) {
       this.showTeamName = true;
@@ -40,4 +43,8 @@ export class OnboardingBannerComponent {
   teamName: string;
   freeTrialCutoffDateMessage: string;
   remainingTrialTimeMessage: string;
+
+  async toggleOnboardingVideo() {
+    await this.workspaceService.toggleOnboardingVideo();
+  }
 }

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
@@ -1,4 +1,4 @@
-@if (showMessage$ | async) {
+@if (isOnboardingVideoVisible()) {
   <div
     class="onboarding-video"
     [style.width.px]="size.width"

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
@@ -7,11 +7,18 @@
     [style.bottom]="position.bottom"
     cdkDrag
     (cdkDragStarted)="onDragStarted()"
-    >
+  >
     <div class="draggable-area" cdkDragHandle>
       <div class="onboarding-video__window-content">
         <div class="onboarding-video__video-container">
-          <button class="onboarding-video__close-button" (click)="dismissVideo()">
+          @if (showCover) {
+            <div class="onboarding-video__cover"></div>
+          }
+
+          <button
+            class="onboarding-video__close-button"
+            (click)="dismissVideo()"
+          >
             ×
           </button>
           <video
@@ -19,19 +26,22 @@
             controls
             preload="metadata"
             (click)="onVideoClick($event)"
-            >
+          >
             <source
               src="https://res.cloudinary.com/hgkbm0qes/video/upload/v1750180118/maptio-onboarding-video.mp4"
               type="video/mp4"
-              />
+            />
             Your browser does not support the video tag.
           </video>
         </div>
       </div>
     </div>
-    @for (handle of ['n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se']; track handle) {
+    @for (
+      handle of ['n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se'];
+      track handle
+    ) {
       <div
-    class="
+        class="
       onboarding-video__resize-handle
       onboarding-video__resize-handle--{{ handle }}
     "

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
@@ -12,7 +12,16 @@
       <div class="onboarding-video__window-content">
         <div class="onboarding-video__video-container">
           @if (showCover) {
-            <div class="onboarding-video__cover"></div>
+            <div class="onboarding-video__cover">
+              <button
+                class="btn btn-info text-white"
+                (click)="hideCoverAndPlayVideo()"
+              >
+                <span class="onboarding-banner__emoji">▶️</span>
+                <ng-container>&nbsp;</ng-container>
+                <ng-container i18n>Play welcome video</ng-container>
+              </button>
+            </div>
           }
 
           <button
@@ -22,6 +31,7 @@
             ×
           </button>
           <video
+            #onboardingVideo
             class="onboarding-video__video"
             controls
             preload="metadata"

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
@@ -13,14 +13,26 @@
         <div class="onboarding-video__video-container">
           @if (showCover) {
             <div class="onboarding-video__cover">
-              <button
-                class="btn btn-info text-white"
-                (click)="hideCoverAndPlayVideo()"
-              >
-                <span class="onboarding-banner__emoji">▶️</span>
-                <ng-container>&nbsp;</ng-container>
-                <ng-container i18n>Play welcome video</ng-container>
-              </button>
+              <div class="onboarding-video__cover-content">
+                <h2 class="onboarding-video__cover-heading" i18n>
+                  Welcome video
+                </h2>
+
+                <button
+                  class="btn btn-info text-white"
+                  (click)="hideCoverAndPlayVideo()"
+                >
+                  <span class="onboarding-banner__emoji">▶️</span>
+                  <ng-container>&nbsp;</ng-container>
+                  <ng-container i18n>Play welcome video</ng-container>
+                </button>
+              </div>
+
+              <img
+                src="assets/images/tom.png"
+                alt="Tom Nixon"
+                class="onboarding-video__cover-tom"
+              />
             </div>
           }
 

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
@@ -58,15 +58,16 @@
         </div>
       </div>
     </div>
+
     @for (
       handle of ['n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se'];
       track handle
     ) {
       <div
         class="
-      onboarding-video__resize-handle
-      onboarding-video__resize-handle--{{ handle }}
-    "
+          onboarding-video__resize-handle
+          onboarding-video__resize-handle--{{ handle }}
+        "
         [class.onboarding-video__resize-handle--disabled]="isResizing"
         (mousedown)="onResizeStart($event, handle)"
       ></div>

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.html
@@ -11,30 +11,31 @@
     <div class="draggable-area" cdkDragHandle>
       <div class="onboarding-video__window-content">
         <div class="onboarding-video__video-container">
-          @if (showCover) {
-            <div class="onboarding-video__cover">
-              <div class="onboarding-video__cover-content">
-                <h2 class="onboarding-video__cover-heading" i18n>
-                  Welcome video
-                </h2>
+          <div
+            class="onboarding-video__cover"
+            [class.onboarding-video__cover--hidden]="!showCover()"
+          >
+            <div class="onboarding-video__cover-content">
+              <h2 class="onboarding-video__cover-heading" i18n>
+                Welcome video
+              </h2>
 
-                <button
-                  class="btn btn-info text-white"
-                  (click)="hideCoverAndPlayVideo()"
-                >
-                  <span class="onboarding-banner__emoji">▶️</span>
-                  <ng-container>&nbsp;</ng-container>
-                  <ng-container i18n>Play welcome video</ng-container>
-                </button>
-              </div>
-
-              <img
-                src="assets/images/tom.png"
-                alt="Tom Nixon"
-                class="onboarding-video__cover-tom"
-              />
+              <button
+                class="btn btn-info text-white"
+                (click)="hideCoverAndPlayVideo()"
+              >
+                <span class="onboarding-banner__emoji">▶️</span>
+                <ng-container>&nbsp;</ng-container>
+                <ng-container i18n>Play welcome video</ng-container>
+              </button>
             </div>
-          }
+
+            <img
+              src="assets/images/tom.png"
+              alt="Tom Nixon"
+              class="onboarding-video__cover-tom"
+            />
+          </div>
 
           <button
             class="onboarding-video__close-button"

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
@@ -84,7 +84,12 @@
   align-items: center;
   justify-content: space-between;
   padding: 1.5rem 2rem;
-  background: yellow;
+
+  background-image: linear-gradient(
+    to left,
+    var(--maptio-accent),
+    var(--maptio-blue)
+  );
 }
 
 .onboarding-video__cover-content {
@@ -93,10 +98,10 @@
 }
 
 .onboarding-video__cover-heading {
-  margin-bottom: 1rem;
-  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  font-size: 1.9rem;
   font-weight: bold;
-  color: #b38f00;
+  color: white;
 }
 
 .onboarding-video__cover-tom {

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
@@ -84,12 +84,17 @@
   align-items: center;
   justify-content: space-between;
   padding: 1.5rem 2rem;
-
+  transition: opacity 0.3s ease;
   background-image: linear-gradient(
     to left,
     var(--maptio-accent),
     var(--maptio-blue)
   );
+}
+
+.onboarding-video__cover--hidden {
+  opacity: 0;
+  pointer-events: none;
 }
 
 .onboarding-video__cover-content {

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
@@ -72,6 +72,17 @@
   object-fit: contain;
 }
 
+.onboarding-video__cover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  background: yellow;
+  z-index: 1;
+}
+
 // Draggable area
 .draggable-area {
   position: absolute;

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
@@ -76,12 +76,36 @@
   position: absolute;
   top: 0;
   left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 2;
   display: flex;
-  width: 100%;
-  height: 100%;
-  padding: 1rem;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
   background: yellow;
-  z-index: 1;
+}
+
+.onboarding-video__cover-content {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.onboarding-video__cover-heading {
+  margin-bottom: 1rem;
+  font-size: 2rem;
+  font-weight: bold;
+  color: #b38f00;
+}
+
+.onboarding-video__cover-tom {
+  display: block;
+  height: 100%;
+  width: auto;
+  margin-left: 1rem;
+  border-radius: 50%;
+  object-fit: cover;
 }
 
 // Draggable area

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.scss
@@ -79,6 +79,7 @@
   display: flex;
   width: 100%;
   height: 100%;
+  padding: 1rem;
   background: yellow;
   z-index: 1;
 }

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
@@ -15,10 +15,10 @@ import { UserService } from '@maptio-shared/services/user/user.service';
 import { PermissionsService } from '@maptio-shared/services/permissions/permissions.service';
 
 @Component({
-    selector: 'maptio-onboarding-video',
-    templateUrl: './onboarding-video.component.html',
-    styleUrls: ['./onboarding-video.component.scss'],
-    imports: [DragDropModule, AsyncPipe]
+  selector: 'maptio-onboarding-video',
+  templateUrl: './onboarding-video.component.html',
+  styleUrls: ['./onboarding-video.component.scss'],
+  imports: [DragDropModule, AsyncPipe],
 })
 export class OnboardingVideoComponent {
   userService = inject(UserService);
@@ -65,14 +65,14 @@ export class OnboardingVideoComponent {
         user &&
         Object.prototype.hasOwnProperty.call(
           user.onboardingProgress,
-          this.messageKey
+          this.messageKey,
         )
       ) {
         return user.onboardingProgress[this.messageKey] === true;
       } else {
         return false;
       }
-    })
+    }),
   );
 
   // This is used to prevent the video from being clicked when dragging
@@ -194,7 +194,7 @@ export class OnboardingVideoComponent {
 
       this.userService.updateUserOnboardingProgress(
         this.user,
-        onboardingProgress
+        onboardingProgress,
       );
       this.hideMessageManually$.next(true);
     }

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
@@ -1,4 +1,10 @@
-import { Component, HostListener, inject } from '@angular/core';
+import {
+  Component,
+  HostListener,
+  inject,
+  ViewChild,
+  ElementRef,
+} from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { BehaviorSubject, combineLatest } from 'rxjs';
@@ -17,6 +23,9 @@ import { PermissionsService } from '@maptio-shared/services/permissions/permissi
 export class OnboardingVideoComponent {
   userService = inject(UserService);
   permissionsService = inject(PermissionsService);
+
+  @ViewChild('onboardingVideo', { static: false })
+  videoRef?: ElementRef<HTMLVideoElement>;
 
   isDragging = false;
   isResizing = false;
@@ -189,5 +198,10 @@ export class OnboardingVideoComponent {
       );
       this.hideMessageManually$.next(true);
     }
+  }
+
+  hideCoverAndPlayVideo() {
+    this.showCover = false;
+    this.videoRef?.nativeElement.play();
   }
 }

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
@@ -42,6 +42,8 @@ export class OnboardingVideoComponent {
   // of the screen
   position = { left: '20px', bottom: '20px' };
 
+  showCover = true;
+
   private hideMessageManually$ = new BehaviorSubject<boolean>(false);
 
   // Show message only if user has not already dismissed it and only if they

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
@@ -4,6 +4,7 @@ import {
   inject,
   ViewChild,
   ElementRef,
+  signal,
 } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { DragDropModule } from '@angular/cdk/drag-drop';
@@ -42,7 +43,7 @@ export class OnboardingVideoComponent {
   // of the screen
   position = { left: '20px', bottom: '20px' };
 
-  showCover = true;
+  showCover = signal(true);
 
   private hideMessageManually$ = new BehaviorSubject<boolean>(false);
 
@@ -203,7 +204,7 @@ export class OnboardingVideoComponent {
   }
 
   hideCoverAndPlayVideo() {
-    this.showCover = false;
+    this.showCover.set(false);
     this.videoRef?.nativeElement.play();
   }
 }

--- a/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
+++ b/apps/maptio/src/app/workspace/onboarding-video/onboarding-video.component.ts
@@ -156,7 +156,7 @@ export class OnboardingVideoComponent {
   }
 
   dismissVideo() {
-    this.workspaceService.hideOnboardingVideo();
+    this.workspaceService.toggleOnboardingVideo();
   }
 
   hideCoverAndPlayVideo() {

--- a/apps/maptio/src/app/workspace/workspace.service.ts
+++ b/apps/maptio/src/app/workspace/workspace.service.ts
@@ -43,6 +43,8 @@ export class WorkspaceService {
   tags = this.datasetService.tags;
   isEmptyMap = this.datasetService.isEmptyMap;
 
+  onboardingVideoMessageKey = 'showOnboardingVideo';
+
   private canSeeOnboardingMessages = toSignal(
     this.permissionsService.canSeeOnboardingMessages$,
   );
@@ -56,17 +58,17 @@ export class WorkspaceService {
       return this.isOnboardingVideoHiddenManually();
     }
 
-    const messageKey = 'showOnboardingVideo';
-
     if (
       this.canSeeOnboardingMessages() &&
       this.user() &&
       Object.prototype.hasOwnProperty.call(
         this.user().onboardingProgress,
-        messageKey,
+        this.onboardingVideoMessageKey,
       )
     ) {
-      return this.user().onboardingProgress[messageKey] === true;
+      return (
+        this.user().onboardingProgress[this.onboardingVideoMessageKey] === true
+      );
     } else {
       return false;
     }
@@ -76,35 +78,21 @@ export class WorkspaceService {
   shouldFocusNewInitiativeName = signal<boolean>(false);
 
   async toggleOnboardingVideo() {
-    if (this.user()) {
-      const messageKey = 'showOnboardingVideo';
-      const onboardingProgress = this.user().onboardingProgress;
-      const newVisibility = !this.isOnboardingVideoVisible();
-
-      onboardingProgress[messageKey] = newVisibility;
-
-      this.isOnboardingVideoHiddenManually.set(newVisibility);
-
-      await this.userService.updateUserOnboardingProgress(
-        this.user(),
-        onboardingProgress,
-      );
+    if (!this.user()) {
+      return;
     }
-  }
 
-  async hideOnboardingVideo() {
-    this.isOnboardingVideoHiddenManually.set(false);
+    const onboardingProgress = this.user().onboardingProgress;
+    const newVisibility = !this.isOnboardingVideoVisible();
 
-    if (this.user()) {
-      const messageKey = 'showOnboardingVideo';
-      const onboardingProgress = this.user().onboardingProgress;
-      onboardingProgress[messageKey] = false;
+    onboardingProgress[this.onboardingVideoMessageKey] = newVisibility;
 
-      await this.userService.updateUserOnboardingProgress(
-        this.user(),
-        onboardingProgress,
-      );
-    }
+    this.isOnboardingVideoHiddenManually.set(newVisibility);
+
+    await this.userService.updateUserOnboardingProgress(
+      this.user(),
+      onboardingProgress,
+    );
   }
 
   loadData(data: DataLoadStructure) {


### PR DESCRIPTION
Adds nice cover to the onboarding video, with Tom's photo. Enables showing and hiding the video from the onboarding banner so that it's easy to return to if needed.

Continuation of #882 , in particular addressing this part (at least the core of it):
> Better (?) yet, we could have a nice "cover" (maybe reusing styles from the older onboarding messages) with buttons like "play video," "go to learning site," "mark as seen" in one corner and your face, Tom, reusing the photo we're already using in the onboarding flow to indicate "hey, I want to tell you something!"). I was thinking this could be nice... though as I started thinking about the details I couldn't quite work these out, so I dropped the idea for now, but perhaps it'd be worth coming back to at some point? Maybe this could be a nice way to make more of this onboarding widget? If we leave the older onboarding messages, then a "cover" like this, styled to look similar to those messages, would make for some lovely consistency!

And this (without the animated minimisation effect achieving the same goal, hopefully!):
> A very much nice-to-have feature would be when the window is closed it gives the impression of it being ‘minimised’ up to the free trial header, perhaps a button with a video icon and the word Demo. So if they close it but want to watch it later they know where it is. I wouldn’t want to spend too much time on this but wanted to log the idea.
