### PR TITLE
Make expanded map the default

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.html
@@ -3,7 +3,7 @@
     class="btn btn-light toolbar-button text-dark p-1 d-flex flex-column justify-content-between align-items-center"
     #rlaCircles="routerLinkActive"
     [routerLinkActive]="['active']"
-    routerLink="/map/{{ datasetId }}/{{ slug }}/expanded-circles"
+    routerLink="/map/{{ datasetId }}/{{ slug }}/expanded"
     ngbTooltip="Expanded Circles"
     i18n-ngbTooltip="@@expanded-circles"
     openDelay="500"
@@ -14,25 +14,23 @@
       class="toolbar-button__image"
       src="assets/images/circles-expanded.svg"
     />
-    <span class="icon-text-label" i18n="@@expanded-circles">
-      Expanded Circles
-    </span>
+    <span class="icon-text-label" i18n="@@expanded">Expanded</span>
   </button>
 
   <button
     class="btn btn-light toolbar-button text-dark p-1 d-flex flex-column justify-content-between align-items-center"
     #rlaCircles="routerLinkActive"
     [routerLinkActive]="['active']"
-    routerLink="/map/{{ datasetId }}/{{ slug }}/covered-circles"
-    ngbTooltip="Covered Circles"
-    i18n-ngbTooltip="@@covered-circles"
+    routerLink="/map/{{ datasetId }}/{{ slug }}/focused"
+    ngbTooltip="Focused Circles"
+    i18n-ngbTooltip="@@focused-circles"
     openDelay="500"
     tooltipClass="toolbar-button__tooltip"
     placement="left"
   >
     <img class="toolbar-button__image" src="assets/images/circles.svg" />
     <span class="icon-text-label">
-      <ng-container i18n="@@covered-circles">Covered Circles</ng-container>
+      <ng-container i18n="@@covered">Focused</ng-container>
     </span>
   </button>
 

--- a/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.html
+++ b/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.html
@@ -3,16 +3,19 @@
     class="btn btn-light toolbar-button text-dark p-1 d-flex flex-column justify-content-between align-items-center"
     #rlaCircles="routerLinkActive"
     [routerLinkActive]="['active']"
-    routerLink="/map/{{ datasetId }}/{{ slug }}/circles"
-    ngbTooltip="Circles"
+    routerLink="/map/{{ datasetId }}/{{ slug }}/expanded-circles"
+    ngbTooltip="Expanded Circles"
+    i18n-ngbTooltip="@@expanded-circles"
     openDelay="500"
     tooltipClass="toolbar-button__tooltip"
     placement="left"
-    i18n-ngbTooltip="@@circles"
-    >
-    <img class="toolbar-button__image" src="assets/images/circles.svg" />
-    <span class="icon-text-label">
-      <ng-container i18n="@@circles">Circles</ng-container>
+  >
+    <img
+      class="toolbar-button__image"
+      src="assets/images/circles-expanded.svg"
+    />
+    <span class="icon-text-label" i18n="@@expanded-circles">
+      Expanded Circles
     </span>
   </button>
 
@@ -20,18 +23,17 @@
     class="btn btn-light toolbar-button text-dark p-1 d-flex flex-column justify-content-between align-items-center"
     #rlaCircles="routerLinkActive"
     [routerLinkActive]="['active']"
-    routerLink="/map/{{ datasetId }}/{{ slug }}/expanded"
-    ngbTooltip="Expanded Circles"
+    routerLink="/map/{{ datasetId }}/{{ slug }}/covered-circles"
+    ngbTooltip="Covered Circles"
+    i18n-ngbTooltip="@@covered-circles"
     openDelay="500"
     tooltipClass="toolbar-button__tooltip"
     placement="left"
-    i18n-ngbTooltip
-    >
-    <img
-      class="toolbar-button__image"
-      src="assets/images/circles-expanded.svg"
-      />
-    <span class="icon-text-label" i18n>Expanded</span>
+  >
+    <img class="toolbar-button__image" src="assets/images/circles.svg" />
+    <span class="icon-text-label">
+      <ng-container i18n="@@covered-circles">Covered Circles</ng-container>
+    </span>
   </button>
 
   <button
@@ -44,7 +46,7 @@
     tooltipClass="toolbar-button__tooltip"
     placement="left"
     i18n-ngbTooltip="@@network"
-    >
+  >
     <img class="toolbar-button__image" src="assets/images/network.png" />
     <span class="d-none d-md-block icon-text-label">
       <ng-container i18n="@@network">Network</ng-container>
@@ -56,7 +58,7 @@
   class="d-flex rounded-end justify-content-center h-100 position-relative bg-white overflow-x-hidden"
   [class.overflow-y-hidden]="!isFullScreen"
   id="mapping-canvas"
-  >
+>
   <div class="w-100">
     <div class="w-100 h-100">
       <div class="row h-100">
@@ -64,7 +66,7 @@
           <div
             class="h-100 w-100 d-flex justify-content-end"
             [class.m-4]="isFullScreen && rlaSummary.isActive"
-            >
+          >
             <router-outlet
               (activate)="onActivate($event)"
               (deactivate)="onDeactivate($event)"
@@ -72,7 +74,7 @@
           </div>
           <div
             class="toolbar d-flex flex-column bg-transparent position-absolute top-right align-items-center align-items-md-end col-12 col-md-auto ms-md-0 me-md-2 ps-md-0 z-index-1"
-            >
+          >
             <div class="btn-group-vertical mb-3 d-none d-md-block">
               <button
                 class="btn btn-light toolbar-button p-1 text-dark d-flex flex-column justify-content-between align-items-center"
@@ -85,7 +87,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@search"
-                >
+              >
                 <i class="mt-2 fa fa-search"></i>
                 <span class="icon-text-label" i18n="@@search">Search</span>
               </button>
@@ -101,7 +103,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@filter"
-                >
+              >
                 <i class="mt-2 fa fa-filter"></i>
                 <span class="icon-text-label" i18n="@@filter">Filter</span>
               </button>
@@ -117,7 +119,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@share"
-                >
+              >
                 <i class="mt-2 fas fa-share"></i>
                 <span class="icon-text-label" i18n="@@share">Share</span>
               </button>
@@ -136,7 +138,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@directory"
-                >
+              >
                 <span class="d-none d-md-block icon-text-label">
                   <ng-container i18n="@@directory">Directory</ng-container>
                 </span>
@@ -157,7 +159,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@zoomout"
-                >
+              >
                 <i class="fa fa-minus py-1"></i>
                 <span class="icon-text-label" i18n="@@zoomout">Zoom out</span>
               </button>
@@ -171,7 +173,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@zoomin"
-                >
+              >
                 <i class="fa fa-plus py-1"></i>
                 <span class="icon-text-label" i18n="@@zoomin">Zoom in</span>
               </button>
@@ -185,7 +187,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@zoomfit"
-                >
+              >
                 <i class="fa fa-expand-arrows-alt py-1"></i>
                 <span class="icon-text-label" i18n="@@zoomfit">Zoom fit</span>
               </button>
@@ -194,7 +196,7 @@
                 <button
                   class="btn btn-light toolbar-button text-dark p-1 d-flex flex-column justify-content-between align-items-center"
                   (click)="fullScreen()"
-                  >
+                >
                   <i
                     class="fas py-1"
                     [class.fa-expand]="!isFullScreen"
@@ -220,7 +222,7 @@
                 tooltipClass="toolbar-button__tooltip"
                 placement="left"
                 i18n-ngbTooltip="@@colors"
-                >
+              >
                 <i class="mt-2 fas fa-palette"></i>
                 <span class="icon-text-label" i18n="@@colors">Colors</span>
               </button>
@@ -245,16 +247,17 @@
   <div
     id="collapsible-options"
     class="d-flex flex-column justify-content-start align-items-end position-absolute pe-3 mx-5 my-2 windows z-index-1"
-    >
+  >
     <div
       id="collapseSearch"
       class="collapse rounded bg-light p-3 mb-3 col-12"
       [class.d-none]="isSearchDisabled"
-      [ngbCollapse]="!isSearchToggled" (ngbCollapseChange)="isSearchToggled = $event"
+      [ngbCollapse]="!isSearchToggled"
+      (ngbCollapseChange)="isSearchToggled = $event"
       [animation]="false"
       closable
       (close)="isSearchToggled = false"
-      >
+    >
       <search
         #search
         [list]="flattenInitiative"
@@ -266,11 +269,12 @@
     <div
       id="collapseFilter"
       class="collapse rounded mb-3 col-12 bg-light p-3"
-      [ngbCollapse]="!isFiltersToggled" (ngbCollapseChange)="isFiltersToggled = $event"
+      [ngbCollapse]="!isFiltersToggled"
+      (ngbCollapseChange)="isFiltersToggled = $event"
       [animation]="false"
       closable
       (close)="isFiltersToggled = false"
-      >
+    >
       <filter-tags
         [isFilterDisabled]="this.isFilterDisabled"
         [expandedMapLink]="'/map/' + datasetId + '/' + slug + '/expanded'"
@@ -283,22 +287,24 @@
     <div
       id="collapseShare"
       class="collapse rounded mb-3 col-12 bg-light p-3"
-      [ngbCollapse]="!isSharingToggled" (ngbCollapseChange)="isSharingToggled = $event"
+      [ngbCollapse]="!isSharingToggled"
+      (ngbCollapseChange)="isSharingToggled = $event"
       [animation]="false"
       closable
       (close)="isSharingToggled = false"
-      >
+    >
       <maptio-sharing [dataset]="dataset"></maptio-sharing>
     </div>
 
     <div
       class="collapse rounded col-auto bg-light p-4"
       id="collapseSettings"
-      [ngbCollapse]="!isSettingToggled" (ngbCollapseChange)="isSettingToggled = $event"
+      [ngbCollapse]="!isSettingToggled"
+      (ngbCollapseChange)="isSettingToggled = $event"
       [animation]="false"
       closable
       (close)="isSettingToggled = false"
-      >
+    >
       <div class="card bg-transparent border-0">
         <div class="card-body">
           <common-color-picker
@@ -317,19 +323,19 @@
 @if (isEmptyMap) {
   <div class="instructions h2 d-none d-md-block">
     <ng-container i18n>
-    Click
+      Click
 
-    <!-- Plus button -->
-    <ng-container
-      *permissionsOnly="
-        Permissions.canCreateRootInitiative;
-        else plusButtonDisabled;
-        then: plusButton
-      "
-    ></ng-container>
+      <!-- Plus button -->
+      <ng-container
+        *permissionsOnly="
+          Permissions.canCreateRootInitiative;
+          else plusButtonDisabled;
+          then: plusButton
+        "
+      ></ng-container>
 
-    to create your first circle
-  </ng-container>
+      to create your first circle
+    </ng-container>
     <ng-template #plusButton>
       <button type="button" class="btn btn-success" (click)="addFirstNode()">
         <i class="fa fa-plus"></i>
@@ -340,7 +346,7 @@
         type="button"
         class="btn btn-success disabled cursor-not-allowed"
         [stickyPopover]="editTipContent"
-        >
+      >
         <i class="fa fa-plus"></i>
       </button>
     </ng-template>
@@ -353,7 +359,7 @@
 @if (isEmptyMap) {
   <div
     class="px-4 d-flex flex-column position-absolute center-center d-md-none w-100 text-center"
-    >
+  >
     <b>Map editing is disable on mobile.</b>
     <span class="text-muted">
       Open Maptio on a desktop to start adding circles

--- a/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.ts
@@ -60,11 +60,11 @@ import { MappingCirclesExpandedComponent } from '@maptio-old-workspace/pages/cir
 import { MappingNetworkComponent } from '@maptio-old-workspace/pages/network/mapping.network.component';
 
 @Component({
-    selector: 'mapping',
-    templateUrl: './mapping.component.html',
-    styleUrls: ['./mapping.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    imports: [
+  selector: 'mapping',
+  templateUrl: './mapping.component.html',
+  styleUrls: ['./mapping.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
     RouterLinkActive,
     RouterLink,
     RouterOutlet,
@@ -79,8 +79,8 @@ import { MappingNetworkComponent } from '@maptio-old-workspace/pages/network/map
     ColorPickerComponent,
     PermissionsDirective,
     StickyPopoverDirective,
-    InsufficientPermissionsMessageComponent
-]
+    InsufficientPermissionsMessageComponent,
+  ],
 })
 export class MappingComponent {
   isFirstEdit: boolean;
@@ -173,7 +173,7 @@ export class MappingComponent {
     private exportService: ExportService,
     private intercom: Intercom,
     private router: Router,
-    private mapSettingsService: MapSettingsService
+    private mapSettingsService: MapSettingsService,
   ) {
     this.zoom$ = new Subject<number>();
     this.isReset$ = new Subject<boolean>();
@@ -225,7 +225,7 @@ export class MappingComponent {
         (tooltip: { initiatives: Initiative[]; isNameOnly: boolean }) => {
           if (tooltip.initiatives)
             this.openDetails.emit(tooltip.initiatives[0]);
-        }
+        },
       );
 
     component.showDetailsOf$.asObservable().subscribe((node) => {
@@ -240,7 +240,7 @@ export class MappingComponent {
     this.x = Number.parseFloat(this.uriService.parseFragment(f).get('x'));
     this.y = Number.parseFloat(this.uriService.parseFragment(f).get('y'));
     this.scale = Number.parseFloat(
-      this.uriService.parseFragment(f).get('scale')
+      this.uriService.parseFragment(f).get('scale'),
     );
 
     const tagsState =
@@ -251,7 +251,8 @@ export class MappingComponent {
             .get('tags')
             .split(',')
             .map(
-              (s: string) => new SelectableTag({ shortid: s, isSelected: true })
+              (s: string) =>
+                new SelectableTag({ shortid: s, isSelected: true }),
             )
         : [];
 
@@ -289,7 +290,7 @@ export class MappingComponent {
       this.isSearchDisabled = false;
       this.isFilterDisabled = false;
       this.isZoomDisabled = false;
-      this.isShareDisabled = true;
+      this.isShareDisabled = false;
       this.toggleEditingPanelsVisibility.emit(true);
     }
   }
@@ -343,8 +344,8 @@ export class MappingComponent {
         map((data) => data[1]),
         combineLatest(
           this.route.fragment,
-          this.route.queryParams.pipe(distinct())
-        )
+          this.route.queryParams.pipe(distinct()),
+        ),
       ) // PEFORMACE : with latest changes
       .subscribe(([data, fragment, queryParams]) => {
         if (
@@ -372,14 +373,14 @@ export class MappingComponent {
                 .split(',')
                 .map(
                   (s: string) =>
-                    new SelectableTag({ shortid: s, isSelected: true })
+                    new SelectableTag({ shortid: s, isSelected: true }),
                 )
             : <SelectableTag[]>[];
 
         this.tags = compact<SelectableTag>(
           data.dataset.tags.map((dataTag: SelectableTag) => {
             const searchTag = fragmentTags.find(
-              (t) => t.shortid === dataTag.shortid
+              (t) => t.shortid === dataTag.shortid,
             );
             return new SelectableTag({
               shortid: dataTag.shortid,
@@ -387,7 +388,7 @@ export class MappingComponent {
               color: dataTag.color,
               isSelected: searchTag !== undefined,
             });
-          })
+          }),
         );
 
         this.dataset = data.dataset;
@@ -551,7 +552,7 @@ export class MappingComponent {
     this.showTooltip(null, null);
     this.cd.markForCheck();
     this.router.navigateByUrl(
-      `/map/${this.datasetId}/${this.slug}/directory?member=${selected.shortid}`
+      `/map/${this.datasetId}/${this.slug}/directory?member=${selected.shortid}`,
     );
   }
 }

--- a/apps/maptio/src/app/workspace/workspace.routes.ts
+++ b/apps/maptio/src/app/workspace/workspace.routes.ts
@@ -42,28 +42,20 @@ export default [
     children: [
       {
         path: '',
-        redirectTo: 'expanded-circles',
+        redirectTo: 'expanded',
         pathMatch: 'full',
       },
       {
         path: 'circles',
-        redirectTo: 'expanded-circles',
-      },
-      {
-        path: 'expanded-circles',
-        component: MappingCirclesExpandedComponent,
+        redirectTo: 'expanded',
       },
       {
         path: 'expanded',
-        redirectTo: 'expanded-circles',
+        component: MappingCirclesExpandedComponent,
       },
       {
-        path: 'covered-circles',
+        path: 'focused',
         component: MappingCirclesGradualRevealComponent,
-      },
-      {
-        path: 'covered',
-        redirectTo: 'covered-circles',
       },
       {
         path: 'tree',

--- a/apps/maptio/src/app/workspace/workspace.routes.ts
+++ b/apps/maptio/src/app/workspace/workspace.routes.ts
@@ -7,7 +7,6 @@ import { AuthGuard } from '@auth0/auth0-angular';
 import { ActivationGuard } from '@maptio-core/guards/activation.guard';
 import { AccessGuard } from '@maptio-core/guards/access.guard';
 import { BillingGuard } from '@maptio-core/guards/billing.guard';
-import { WorkspaceGuard } from '@maptio-core/guards/workspace.guard';
 
 import * as fromWorkspace from '@maptio-old-workspace/+state/workspace.reducer';
 import { WorkspaceComponentResolver } from '@maptio-old-workspace/pages/workspace/workspace.resolver';
@@ -41,31 +40,42 @@ export default [
     ],
 
     children: [
-      { path: '', redirectTo: 'circles', pathMatch: 'full' },
+      {
+        path: '',
+        redirectTo: 'expanded-circles',
+        pathMatch: 'full',
+      },
       {
         path: 'circles',
-        component: MappingCirclesGradualRevealComponent,
-        // canActivate: [WorkspaceGuard],
+        redirectTo: 'expanded-circles',
+      },
+      {
+        path: 'expanded-circles',
+        component: MappingCirclesExpandedComponent,
       },
       {
         path: 'expanded',
-        component: MappingCirclesExpandedComponent,
-        // canActivate: [WorkspaceGuard],
+        redirectTo: 'expanded-circles',
+      },
+      {
+        path: 'covered-circles',
+        component: MappingCirclesGradualRevealComponent,
+      },
+      {
+        path: 'covered',
+        redirectTo: 'covered-circles',
       },
       {
         path: 'tree',
         component: MappingTreeComponent,
-        // canActivate: [WorkspaceGuard],
       },
       {
         path: 'network',
         component: MappingNetworkComponent,
-        // canActivate: [WorkspaceGuard],
       },
       {
         path: 'directory',
         component: MappingSummaryComponent,
-        // canActivate: [WorkspaceGuard],
         children: [
           { path: '', redirectTo: 'people', pathMatch: 'full' },
           {


### PR DESCRIPTION
We've decided to make the expanded map the default view. This also renames the non-expanded map from "circles" to "focused." Tom's good rationale for the name:
> this goes back to the original intention of this view when seeing the whole map open is overwhelming when you want to explore and focus on one area at a time.
